### PR TITLE
Refactor and expand specs

### DIFF
--- a/lib/keisan/ast/builder.rb
+++ b/lib/keisan/ast/builder.rb
@@ -3,8 +3,8 @@ module Keisan
     class Builder
       # Build from parser
       def initialize(string: nil, parser: nil, components: nil)
-        if string.nil? && parser.nil? && components.nil?
-          raise Keisan::Exceptions::InternalError.new("Require parser or components")
+        if [string, parser, components].select(&:nil?).size != 2
+          raise Keisan::Exceptions::InternalError.new("Require one of string, parser or components")
         end
 
         if !string.nil?

--- a/lib/keisan/calculator.rb
+++ b/lib/keisan/calculator.rb
@@ -7,16 +7,18 @@ module Keisan
     end
 
     def evaluate(expression, definitions = {})
-      local_context = context.spawn_child
-      definitions.each do |name, value|
-        case value
-        when Proc
-          local_context.register_function!(name, value)
-        else
-          local_context.register_variable!(name, value)
+      context.spawn_child do |local|
+        definitions.each do |name, value|
+          case value
+          when Proc
+            local.register_function!(name, value)
+          else
+            local.register_variable!(name, value)
+          end
         end
+
+        Keisan::AST::Builder.new(string: expression).ast.value(local)
       end
-      Keisan::AST::Builder.new(string: expression).ast.value(local_context)
     end
 
     def define_variable!(name, value)

--- a/lib/keisan/context.rb
+++ b/lib/keisan/context.rb
@@ -10,7 +10,11 @@ module Keisan
     end
 
     def spawn_child
-      self.class.new(parent: self)
+      if block_given?
+        yield self.class.new(parent: self)
+      else
+        self.class.new(parent: self)
+      end
     end
 
     def function(name)

--- a/lib/keisan/parser.rb
+++ b/lib/keisan/parser.rb
@@ -67,8 +67,10 @@ module Keisan
         end
 
       elsif @components[-1].is_a?(Parsing::Element)
+        # A word followed by a "round group" is actually a function: e.g. sin(x)
         if @components[-1].is_a?(Parsing::Variable) && token.type == :group && token.group_type == :round
           add_function_to_components!(token)
+        # Here it is a postfix Indexing (access elements by index)
         elsif token.type == :group && token.group_type == :square
           add_indexing_to_components!(token)
         else

--- a/lib/keisan/parser.rb
+++ b/lib/keisan/parser.rb
@@ -80,7 +80,7 @@ module Keisan
         end
 
       else
-        raise Keisan::Exceptions::InternalError.new("Invalid parsing!")
+        raise Keisan::Exceptions::ParseError.new("Token cannot be parsed, #{token.string}")
       end
     end
 

--- a/lib/keisan/tokenizer.rb
+++ b/lib/keisan/tokenizer.rb
@@ -26,6 +26,9 @@ module Keisan
     end
 
     def self.strip_whitespace(expression)
+      # Do not allow whitespace between variables, numbers, and the like; they must be joined by operators
+      raise Keisan::Exceptions::TokenizingError.new if expression.gsub(Tokens::String.regex, "").match /\w\s+\w/
+
       # Only strip whitespace outside of strings, e.g.
       # "1 + 2 + 'hello world'" => "1+2+'hello world'"
       expression.split(Keisan::Tokens::String.regex).map.with_index {|s,i| i.even? ? s.gsub(/\s+/, "") : s}.join

--- a/lib/keisan/tokens/number.rb
+++ b/lib/keisan/tokens/number.rb
@@ -3,7 +3,7 @@ module Keisan
     class Number < Token
       INTEGER_REGEX = /\d+/
       FLOATING_POINT_REGEX = /\d+\.\d+/
-      SCIENTIFC_NOTATION_REGEX = /\d+(?:\.\d+)e(?:\+|\-)?\d+/
+      SCIENTIFIC_NOTATION_REGEX = /\d+(?:\.\d+)?e(?:\+|\-)?\d+/
 
       REGEX = /(\d+(?:\.\d+)?(?:e(?:\+|\-)?\d+)?)/
 
@@ -13,9 +13,9 @@ module Keisan
 
       def value
         case string
-        when SCIENTIFC_NOTATION_REGEX, FLOATING_POINT_REGEX
+        when /\A#{SCIENTIFIC_NOTATION_REGEX}\z/, /\A#{FLOATING_POINT_REGEX}\z/
           Float(string)
-        when INTEGER_REGEX
+        when /\A#{INTEGER_REGEX}\z/
           Integer(string)
         end
       end

--- a/lib/keisan/tokens/word.rb
+++ b/lib/keisan/tokens/word.rb
@@ -1,7 +1,7 @@
 module Keisan
   module Tokens
     class Word < Token
-      REGEX = /([a-zA-Z0-9_]*[a-zA-Z][a-zA-Z0-9_]*)/
+      REGEX = /([a-zA-Z_]\w*)/
 
       def self.regex
         REGEX

--- a/spec/keisan/tokenizer_spec.rb
+++ b/spec/keisan/tokenizer_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Keisan::Tokenizer do
   context "invalid symbols" do
     it "raises a TokenizingError" do
       expect { described_class.new("2%3") }.to raise_error(Keisan::Exceptions::TokenizingError)
+      expect { described_class.new("1 1") }.to raise_error(Keisan::Exceptions::TokenizingError)
     end
   end
 

--- a/spec/keisan/tokenizer_spec.rb
+++ b/spec/keisan/tokenizer_spec.rb
@@ -40,16 +40,32 @@ RSpec.describe Keisan::Tokenizer do
     end
 
     context "scientific notation" do
-      it "gets scientific notation numbers correctly" do
-        tokenizer = described_class.new("6.001e-3")
+      context "positive exponent" do
+        it "gets scientific notation numbers correctly" do
+          tokenizer = described_class.new("6.001e-3")
 
-        expect(tokenizer.tokens.map(&:class)).to match_array([
-          Keisan::Tokens::Number
-        ])
+          expect(tokenizer.tokens.map(&:class)).to match_array([
+            Keisan::Tokens::Number
+          ])
 
-        expect(tokenizer.tokens[0].string).to eq "6.001e-3"
-        expect(tokenizer.tokens[0].value).to be_a Float
-        expect(tokenizer.tokens[0].value).to eq 0.006001
+          expect(tokenizer.tokens[0].string).to eq "6.001e-3"
+          expect(tokenizer.tokens[0].value).to be_a Float
+          expect(tokenizer.tokens[0].value).to eq 0.006001
+        end
+      end
+
+      context "negative exponent" do
+        it "gets scientific notation numbers correctly" do
+          tokenizer = described_class.new("1234e2")
+
+          expect(tokenizer.tokens.map(&:class)).to match_array([
+            Keisan::Tokens::Number
+          ])
+
+          expect(tokenizer.tokens[0].string).to eq "1234e2"
+          expect(tokenizer.tokens[0].value).to be_a Float
+          expect(tokenizer.tokens[0].value).to eq 123400.0
+        end
       end
     end
   end

--- a/spec/keisan/tokenizer_spec.rb
+++ b/spec/keisan/tokenizer_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Keisan::Tokenizer do
     end
 
     context "scientific notation" do
-      context "positive exponent" do
+      context "negative exponent" do
         it "gets scientific notation numbers correctly" do
           tokenizer = described_class.new("6.001e-3")
 
@@ -54,7 +54,7 @@ RSpec.describe Keisan::Tokenizer do
         end
       end
 
-      context "negative exponent" do
+      context "positive exponent" do
         it "gets scientific notation numbers correctly" do
           tokenizer = described_class.new("1234e2")
 


### PR DESCRIPTION
Does some refactoring of long methods, adds a few specs.

There was also a bug fixed that involved parsing of scientific notation numbers and variable names.  The following would register as a `Word` incorrectly before:

```ruby
Keisan::Tokenizer.new("1234e2").tokens.first.is_a?(Keisan::Tokens::Word)
#=> true
```

After it is correct
```ruby
Keisan::Tokenizer.new("1234e2").tokens.first.is_a?(Keisan::Tokens::Number)
#=> true
Keisan::Tokenizer.new("1234e2").tokens.first.value
#=> 123400.0
```