### PR TITLE
Handling binary octal hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ calculator.evaluate("'hello'[1]")
 #=> "e"
 ```
 
+##### Binary, octal, and hexadecimal numbers
+
+Using the prefixes `0b`, `0o`, and `0x` (standard in Ruby) indicates binary, octal, and hexadecimal numbers respectively.
+
+```ruby
+calculator.evaluate("0b1100")
+#=> 12
+calculator.evaluate("0o775")
+#=> 504
+calculator.evaluate("0x1f0")
+#=> 496
+```
+
 ##### Random numbers
 
 `keisan` has a couple methods for doing random operations, `rand` and `sample`.  For example,

--- a/lib/keisan/tokens/number.rb
+++ b/lib/keisan/tokens/number.rb
@@ -2,10 +2,13 @@ module Keisan
   module Tokens
     class Number < Token
       INTEGER_REGEX = /\d+/
+      BINARY_REGEX = /0b[0-1]+/
+      OCTAL_REGEX = /0o[0-7]+/
+      HEX_REGEX = /0x[0-9a-f]+/
       FLOATING_POINT_REGEX = /\d+\.\d+/
       SCIENTIFIC_NOTATION_REGEX = /\d+(?:\.\d+)?e(?:\+|\-)?\d+/
 
-      REGEX = /(\d+(?:\.\d+)?(?:e(?:\+|\-)?\d+)?)/
+      REGEX = /(#{BINARY_REGEX}|#{OCTAL_REGEX}|#{HEX_REGEX}|\d+(?:\.\d+)?(?:e(?:\+|\-)?\d+)?)/
 
       def self.regex
         REGEX
@@ -13,9 +16,9 @@ module Keisan
 
       def value
         case string
-        when /\A#{SCIENTIFIC_NOTATION_REGEX}\z/, /\A#{FLOATING_POINT_REGEX}\z/
+        when /\A#{SCIENTIFIC_NOTATION_REGEX}\z/.freeze, /\A#{FLOATING_POINT_REGEX}\z/.freeze
           Float(string)
-        when /\A#{INTEGER_REGEX}\z/
+        else
           Integer(string)
         end
       end

--- a/spec/keisan/tokenizer_spec.rb
+++ b/spec/keisan/tokenizer_spec.rb
@@ -25,6 +25,33 @@ RSpec.describe Keisan::Tokenizer do
       end
     end
 
+    context "binary" do
+      it "parses correctly" do
+        tokenizer = described_class.new("0b1100")
+        expect(tokenizer.tokens.map(&:class)).to match_array([Keisan::Tokens::Number])
+        expect(tokenizer.tokens[0].string).to eq "0b1100"
+        expect(tokenizer.tokens[0].value).to eq 12
+      end
+    end
+
+    context "octal" do
+      it "parses correctly" do
+        tokenizer = described_class.new("0o775")
+        expect(tokenizer.tokens.map(&:class)).to match_array([Keisan::Tokens::Number])
+        expect(tokenizer.tokens[0].string).to eq "0o775"
+        expect(tokenizer.tokens[0].value).to eq 7*8**2 + 7*8 + 5
+      end
+    end
+
+    context "hexadecimal" do
+      it "parses correctly" do
+        tokenizer = described_class.new("0x1f0")
+        expect(tokenizer.tokens.map(&:class)).to match_array([Keisan::Tokens::Number])
+        expect(tokenizer.tokens[0].string).to eq "0x1f0"
+        expect(tokenizer.tokens[0].value).to eq 256 + 15*16
+      end
+    end
+
     context "floating point" do
       it "gets floating point numbers correctly" do
         tokenizer = described_class.new("56.09")


### PR DESCRIPTION
Using the prefixes `0b`, `0o`, and `0x` (standard in Ruby) indicates binary, octal, and hexadecimal numbers respectively.

```ruby
calculator.evaluate("0b1100")
#=> 12
calculator.evaluate("0o775")
#=> 504
calculator.evaluate("0x1f0")
#=> 496
```