### PR TITLE
Handle older ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.2.6
+  - 2.3.3
   - 2.4.0
   - 2.4.1
 before_install: gem install bundler -v 1.14.6

--- a/keisan.gemspec
+++ b/keisan.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = ">= 2.0.0"
 
   spec.add_dependency "activesupport", ">= 4.2.2"
 

--- a/lib/keisan/tokens/group.rb
+++ b/lib/keisan/tokens/group.rb
@@ -1,7 +1,7 @@
 module Keisan
   module Tokens
     class Group < Token
-      REGEX = /(\((?:[^\[\]\(\)]*\g<0>*)*\)|\[(?:[^\[\]\(\)]*\g<0>*)*\])/
+      REGEX = /(\((?:[^\[\]\(\)]*\g<1>*)*\)|\[(?:[^\[\]\(\)]*\g<1>*)*\])/
 
       attr_reader :sub_tokens
 


### PR DESCRIPTION
There was a difference in handling of 0-th group recursive regular expressions between Ruby 2.4 and lower version (see [here](https://stackoverflow.com/questions/43007936/discrepancy-in-scan-and-match-behavior-for-different-ruby-versions)).  This pull request fixes this problem, and opens up the lower Ruby version limit.