### PR TITLE
Calculator can evaluate definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,21 @@ calculator.evaluate("4.f[1].size")
 #=> 3
 ```
 
-Like variables, it is also possible to define functions in the string expression itself
+Like variables, it is also possible to define functions in the string expression itself.  This form even supports recursion!
 
 ```ruby
 calculator.evaluate("f(x) = n*x", n: 10)
 calculator.evaluate("f(3)")
 #=> 30
+calculator.evaluate("my_fact(n) = if (n > 1, n*my_fact(n-1), 1)")
+calculator.evaluate("my_fact(0)")
+#=> 1
+calculator.evaluate("my_fact(1)")
+#=> 1
+calculator.evaluate("my_fact(2)")
+#=> 2
+calculator.evaluate("my_fact(5)")
+#=> 120
 ```
 
 ##### Lists

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ calculator.evaluate("x + 1")
 #=> Keisan::Exceptions::UndefinedVariableError: x
 ```
 
+It is also possible to define variables in the string expression itself
+
+```ruby
+calculator.evaluate("x = 10*n", n: 2)
+calculator.evaluate("3*x + 1")
+#=> 61
+```
+
 ##### Specifying functions
 
 Just like variables, functions can be defined by passing a `Proc` object as follows
@@ -90,6 +98,14 @@ calculator.evaluate("4.f[1]")
 #=> [2,4,6]
 calculator.evaluate("4.f[1].size")
 #=> 3
+```
+
+Like variables, it is also possible to define functions in the string expression itself
+
+```ruby
+calculator.evaluate("f(x) = n*x", n: 10)
+calculator.evaluate("f(3)")
+#=> 30
 ```
 
 ##### Lists

--- a/lib/keisan.rb
+++ b/lib/keisan.rb
@@ -118,6 +118,7 @@ require "keisan/parsing/logical_not_not"
 require "keisan/parser"
 
 require "keisan/calculator"
+require "keisan/evaluator"
 
 module Keisan
 end

--- a/lib/keisan/ast/builder.rb
+++ b/lib/keisan/ast/builder.rb
@@ -69,16 +69,16 @@ module Keisan
             }
           )
         when Keisan::Parsing::DotWord
-          Keisan::AST::Function.new(
-            [node],
-            postfix_component.name
+          Keisan::AST::Function.build(
+            postfix_component.name,
+            [node]
           )
         when Keisan::Parsing::DotOperator
-          Keisan::AST::Function.new(
+          Keisan::AST::Function.build(
+            postfix_component.name,
             [node] + postfix_component.arguments.map {|parsing_argument|
               Builder.new(components: parsing_argument.components).node
-            },
-            postfix_component.name
+            }
           )
         else
           raise Keisan::Exceptions::ASTError.new("Invalid postfix component #{postfix_component}")
@@ -139,23 +139,23 @@ module Keisan
         when Keisan::Parsing::Group
           Builder.new(components: component.components).node
         when Keisan::Parsing::Function
-          Keisan::AST::Function.new(
+          Keisan::AST::Function.build(
+            component.name,
             component.arguments.map {|parsing_argument|
               Builder.new(components: parsing_argument.components).node
-            },
-            component.name
+            }
           )
         when Keisan::Parsing::DotWord
-          Keisan::AST::Function.new(
-            [node_of_component(component.target)],
-            component.name
+          Keisan::AST::Function.build(
+            component.name,
+            [node_of_component(component.target)]
           )
         when Keisan::Parsing::DotOperator
-          Keisan::AST::Function.new(
+          Keisan::AST::Function.build(
+            component.name,
             [node_of_component(component.target)] + component.arguments.map {|parsing_argument|
               Builder.new(components: parsing_argument.components).node
-            },
-            component.name
+            }
           )
         else
           raise Keisan::Exceptions::ASTError.new("Unhandled component, #{component}")

--- a/lib/keisan/ast/function.rb
+++ b/lib/keisan/ast/function.rb
@@ -28,14 +28,6 @@ module Keisan
       def function_from_context(context)
         @override || context.function(name)
       end
-
-      def fill_unbound_function(override_name, function)
-        if name == override_name
-          @override = Keisan::Function.new(name, function)
-        else
-          children.each {|child| child.fill_unbound_function(override_name, function)}
-        end
-      end
     end
 
     class If < Function

--- a/lib/keisan/ast/node.rb
+++ b/lib/keisan/ast/node.rb
@@ -30,17 +30,6 @@ module Keisan
           Set.new
         end
       end
-
-      def fill_unbound_function(name, function)
-        case self
-        when Parent
-          children.each do |child|
-            child.fill_unbound_function(name, function)
-          end
-        when Function
-          self.fill_unbound_function(name, function)
-        end
-      end
     end
   end
 end

--- a/lib/keisan/ast/node.rb
+++ b/lib/keisan/ast/node.rb
@@ -30,6 +30,17 @@ module Keisan
           Set.new
         end
       end
+
+      def fill_unbound_function(name, function)
+        case self
+        when Parent
+          children.each do |child|
+            child.fill_unbound_function(name, function)
+          end
+        when Function
+          self.fill_unbound_function(name, function)
+        end
+      end
     end
   end
 end

--- a/lib/keisan/calculator.rb
+++ b/lib/keisan/calculator.rb
@@ -7,18 +7,7 @@ module Keisan
     end
 
     def evaluate(expression, definitions = {})
-      context.spawn_child do |local|
-        definitions.each do |name, value|
-          case value
-          when Proc
-            local.register_function!(name, value)
-          else
-            local.register_variable!(name, value)
-          end
-        end
-
-        Keisan::AST::Builder.new(string: expression).ast.value(local)
-      end
+      Evaluator.new(self).evaluate(expression, definitions)
     end
 
     def define_variable!(name, value)

--- a/lib/keisan/context.rb
+++ b/lib/keisan/context.rb
@@ -9,12 +9,19 @@ module Keisan
       @random            = random
     end
 
-    def spawn_child
-      if block_given?
-        yield self.class.new(parent: self)
-      else
-        self.class.new(parent: self)
+    def spawn_child(definitions = {})
+      child = self.class.new(parent: self)
+
+      definitions.each do |name, value|
+        case value
+        when Proc
+          child.register_function!(name, value)
+        else
+          child.register_variable!(name, value)
+        end
       end
+
+      child
     end
 
     def function(name)

--- a/lib/keisan/evaluator.rb
+++ b/lib/keisan/evaluator.rb
@@ -24,37 +24,28 @@ module Keisan
     private
 
     def variable_evaluate(expression, definitions = {})
-      unless definitions.empty?
-        raise Keisan::Exceptions::InvalidExpression.new("Cannot use local definitions for definition expression") unless definitions.empty?
-      end
-
       match = expression.match VARIABLE_DEFINITION
       name = match[1]
       expression = match[2]
       ast = Keisan::AST::Builder.new(string: expression).ast
 
-      context = calculator.context
+      context = calculator.context.spawn_child(definitions)
       unbound_variables = ast.unbound_variables(context)
       unless unbound_variables <= Set.new([name])
         raise Keisan::Exceptions::InvalidExpression.new("Unbound variables found in variable definition")
       end
 
-      context.register_variable!(name, ast.value(context))
+      calculator.context.register_variable!(name, ast.value(context))
     end
 
     def function_evaluate(expression, definitions = {})
-      unless definitions.empty?
-        raise Keisan::Exceptions::InvalidExpression.new("Cannot use local definitions for definition expression") unless definitions.empty?
-      end
-
       match = expression.match FUNCTION_DEFINITION
       name = match[1]
       args = match[2].split(",").map(&:strip)
       expression = match[3]
       ast = Keisan::AST::Builder.new(string: expression).ast
 
-      context = calculator.context
-
+      context = calculator.context.spawn_child(definitions)
       unbound_variables = ast.unbound_variables(context)
       unbound_functions = ast.unbound_functions(context)
       # Ensure the variables are contained within the arguments
@@ -62,39 +53,25 @@ module Keisan
         raise Keisan::Exceptions::InvalidExpression.new("Unbound variables found in function definition")
       end
 
-      context.register_function!(
+      calculator.context.register_function!(
         name,
         Proc.new do |*received_args|
           unless args.count == received_args.count
             raise Keisan::Exceptions::InvalidFunctionError.new("Invalid number of arguments for #{name} function")
           end
 
-          local = context.spawn_child
+          local = calculator.context.spawn_child(definitions)
           args.each.with_index do |arg, i|
             local.register_variable!(arg, received_args[i])
           end
+
           ast.value(local)
         end
       )
     end
 
     def pure_evaluate(expression, definitions = {})
-      local = calculator.context.spawn_child
-
-      definitions.each do |name, value|
-        case value
-        when Proc
-          local.register_function!(name, value)
-        else
-          local.register_variable!(name, value)
-        end
-      end
-
-      evaluate_expression(expression, local)
-    end
-
-    def evaluate_expression(expression, context)
-      Keisan::AST::Builder.new(string: expression).ast.value(context)
+      Keisan::AST::Builder.new(string: expression).ast.value(calculator.context.spawn_child(definitions))
     end
   end
 end

--- a/lib/keisan/evaluator.rb
+++ b/lib/keisan/evaluator.rb
@@ -1,0 +1,100 @@
+module Keisan
+  class Evaluator
+    WORD = /[a-zA-Z_]\w*/
+    VARIABLE_DEFINITION = /\A\s*(#{WORD})\s*=\s*(.+)\z/
+    FUNCTION_DEFINITION = /\A\s*(#{WORD})\s*\(((?:\s*#{WORD}\s*)(?:,\s*#{WORD}\s*)*)\)\s*=\s*(.+)\z/
+
+    attr_reader :calculator
+
+    def initialize(calculator)
+      @calculator = calculator
+    end
+
+    def evaluate(expression, definitions = {})
+      case expression
+      when VARIABLE_DEFINITION
+        variable_evaluate(expression, definitions)
+      when FUNCTION_DEFINITION
+        function_evaluate(expression, definitions)
+      else
+        pure_evaluate(expression, definitions)
+      end
+    end
+
+    private
+
+    def variable_evaluate(expression, definitions = {})
+      unless definitions.empty?
+        raise Keisan::Exceptions::InvalidExpression.new("Cannot use local definitions for definition expression") unless definitions.empty?
+      end
+
+      match = expression.match VARIABLE_DEFINITION
+      name = match[1]
+      expression = match[2]
+      ast = Keisan::AST::Builder.new(string: expression).ast
+
+      context = calculator.context
+      unbound_variables = ast.unbound_variables(context)
+      unless unbound_variables <= Set.new([name])
+        raise Keisan::Exceptions::InvalidExpression.new("Unbound variables found in variable definition")
+      end
+
+      context.register_variable!(name, ast.value(context))
+    end
+
+    def function_evaluate(expression, definitions = {})
+      unless definitions.empty?
+        raise Keisan::Exceptions::InvalidExpression.new("Cannot use local definitions for definition expression") unless definitions.empty?
+      end
+
+      match = expression.match FUNCTION_DEFINITION
+      name = match[1]
+      args = match[2].split(",").map(&:strip)
+      expression = match[3]
+      ast = Keisan::AST::Builder.new(string: expression).ast
+
+      context = calculator.context
+
+      unbound_variables = ast.unbound_variables(context)
+      unbound_functions = ast.unbound_functions(context)
+      # Ensure the variables are contained within the arguments
+      unless unbound_variables <= Set.new(args) && unbound_functions.empty?
+        raise Keisan::Exceptions::InvalidExpression.new("Unbound variables found in function definition")
+      end
+
+      context.register_function!(
+        name,
+        Proc.new do |*received_args|
+          unless args.count == received_args.count
+            raise Keisan::Exceptions::InvalidFunctionError.new("Invalid number of arguments for #{name} function")
+          end
+
+          local = context.spawn_child
+          args.each.with_index do |arg, i|
+            local.register_variable!(arg, received_args[i])
+          end
+          ast.value(local)
+        end
+      )
+    end
+
+    def pure_evaluate(expression, definitions = {})
+      local = calculator.context.spawn_child
+
+      definitions.each do |name, value|
+        case value
+        when Proc
+          local.register_function!(name, value)
+        else
+          local.register_variable!(name, value)
+        end
+      end
+
+      evaluate_expression(expression, local)
+    end
+
+    def evaluate_expression(expression, context)
+      Keisan::AST::Builder.new(string: expression).ast.value(context)
+    end
+  end
+end

--- a/lib/keisan/evaluator.rb
+++ b/lib/keisan/evaluator.rb
@@ -63,8 +63,6 @@ module Keisan
           local.register_variable!(arg, received_args[i])
         end
 
-        ast.fill_unbound_function(name, function)
-
         ast.value(local)
       end
 

--- a/lib/keisan/exceptions.rb
+++ b/lib/keisan/exceptions.rb
@@ -15,5 +15,6 @@ module Keisan
     class UndefinedFunctionError < StandardError; end
     class UndefinedVariableError < StandardError; end
     class UnmodifiableError < StandardError; end
+    class InvalidExpression < StandardError; end
   end
 end

--- a/lib/keisan/functions/default_registry.rb
+++ b/lib/keisan/functions/default_registry.rb
@@ -14,7 +14,6 @@ module Keisan
 
       def self.register_defaults!(registry)
         register_builtin_math!(registry)
-        register_branch_methods!(registry)
         register_array_methods!(registry)
         register_random_methods!(registry)
       end
@@ -28,10 +27,6 @@ module Keisan
             end
           )
         end
-      end
-
-      def self.register_branch_methods!(registry)
-        registry.register!(:if, Proc.new {|bool, a, b=nil| bool ? a : b })
       end
 
       def self.register_array_methods!(registry)

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -103,5 +103,14 @@ RSpec.describe Keisan::Calculator do
         expect(calculator.evaluate("f(3)")).to eq 30
       end
     end
+
+    context "recursive" do
+      it "can define factorial" do
+        calculator.evaluate("my_fact(n) = if (n > 1, n*my_fact(n-1), 1)")
+        expect(calculator.evaluate("my_fact(0)")).to eq 1
+        expect(calculator.evaluate("my_fact(1)")).to eq 1
+        expect(calculator.evaluate("my_fact(5)")).to eq 120
+      end
+    end
   end
 end

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -61,4 +61,28 @@ RSpec.describe Keisan::Calculator do
       expect(calculator.evaluate("95 % (7 % 5)")).to eq 1
     end
   end
+
+  describe "defining variables" do
+    it "raises an error if there is an undefined variable" do
+      expect{calculator.evaluate("x = y")}.to raise_error(Keisan::Exceptions::InvalidExpression)
+
+      expect(calculator.evaluate("y = 2")).to eq 2
+      expect(calculator.evaluate("y")).to eq 2
+
+      expect(calculator.evaluate("x = 2*y")).to eq 4
+      expect(calculator.evaluate("3*x + y**2")).to eq 12 + 4
+    end
+  end
+
+  describe "defining functions" do
+    it "raises an error if there is an undefined variable" do
+      expect{calculator.evaluate("f(x) = n*x")}.to raise_error(Keisan::Exceptions::InvalidExpression)
+
+      calculator.evaluate("f(x) = 4*x")
+      expect(calculator.evaluate("f(3)")).to eq 12
+
+      calculator.evaluate("g(x,y) = -2*x + f(y)")
+      expect(calculator.evaluate("g(7, 5)")).to eq -2*7 + 4*5
+    end
+  end
 end

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -65,24 +65,43 @@ RSpec.describe Keisan::Calculator do
   describe "defining variables" do
     it "raises an error if there is an undefined variable" do
       expect{calculator.evaluate("x = y")}.to raise_error(Keisan::Exceptions::InvalidExpression)
+    end
 
+    it "can define variables" do
       expect(calculator.evaluate("y = 2")).to eq 2
       expect(calculator.evaluate("y")).to eq 2
 
       expect(calculator.evaluate("x = 2*y")).to eq 4
       expect(calculator.evaluate("3*x + y**2")).to eq 12 + 4
     end
+
+    context "with definitions" do
+      it "raises an error if there is an undefined variable" do
+        calculator.evaluate("x = n", n: 10)
+        expect{calculator.evaluate("n")}.to raise_error(Keisan::Exceptions::UndefinedVariableError)
+        expect(calculator.evaluate("x")).to eq 10
+      end
+    end
   end
 
   describe "defining functions" do
     it "raises an error if there is an undefined variable" do
       expect{calculator.evaluate("f(x) = n*x")}.to raise_error(Keisan::Exceptions::InvalidExpression)
+    end
 
+    it "can define functions" do
       calculator.evaluate("f(x) = 4*x")
       expect(calculator.evaluate("f(3)")).to eq 12
 
       calculator.evaluate("g(x,y) = -2*x + f(y)")
       expect(calculator.evaluate("g(7, 5)")).to eq -2*7 + 4*5
+    end
+
+    context "with definitions" do
+      it "raises an error if there is an undefined variable" do
+        calculator.evaluate("f(x) = n*x", n: 10)
+        expect(calculator.evaluate("f(3)")).to eq 30
+      end
     end
   end
 end

--- a/spec/keisan/default_functions_spec.rb
+++ b/spec/keisan/default_functions_spec.rb
@@ -11,20 +11,6 @@ RSpec.describe Keisan::Functions::DefaultRegistry do
     expect { registry.register!(:bad, Proc.new { false }) }.to raise_error(Keisan::Exceptions::UnmodifiableError)
   end
 
-  context "if" do
-    it "works as expected" do
-      expect(registry["if"].name).to eq "if"
-      expect(registry["if"].call(nil, false, 2, 3)).to eq 3
-
-      expect(Keisan::Calculator.new.evaluate("if(true, 2)")).to eq 2
-      expect(Keisan::Calculator.new.evaluate("if(false, 2)")).to eq nil
-      expect(Keisan::Calculator.new.evaluate("if(true, 2, 4)")).to eq 2
-      expect(Keisan::Calculator.new.evaluate("if(false, 2, 4)")).to eq 4
-      expect(Keisan::Calculator.new.evaluate("if(true, nil, 4)")).to eq nil
-      expect(Keisan::Calculator.new.evaluate("if(false, nil, 4)")).to eq 4
-    end
-  end
-
   context "array methods" do
     it "works as expected" do
       expect(registry["min"].name).to eq "min"


### PR DESCRIPTION
Allows for string based definitions of variables and functions

```ruby
calculator.evaluate("N = 10")
calculator.evaluate("2*N")
#=> 20

calculator.evaluate("fact(n) = if (n > 1, n*fact(n-1), 1)")
calculator.evaluate("fact(5)")
#=> 120
```