### PR TITLE
More symbolic

### DIFF
--- a/lib/keisan/ast/constant_literal.rb
+++ b/lib/keisan/ast/constant_literal.rb
@@ -17,7 +17,7 @@ module Keisan
       end
 
       def coerce(other)
-        [self.class.from_value(other), self]
+        [self, self.class.from_value(other)]
       end
 
       def to_s

--- a/lib/keisan/ast/constant_literal.rb
+++ b/lib/keisan/ast/constant_literal.rb
@@ -12,7 +12,7 @@ module Keisan
         when NilClass
           AST::Null.new
         else
-          raise TypeError.new("#{value}'s type is invalid, #{value.class}")
+          raise Keisan::Exceptions::TypeError.new("#{value}'s type is invalid, #{value.class}")
         end
       end
 

--- a/lib/keisan/ast/exponent.rb
+++ b/lib/keisan/ast/exponent.rb
@@ -25,7 +25,7 @@ module Keisan
         end
 
         if children.all? {|child| child.is_a?(ConstantLiteral)}
-          children[0] ** children[1]
+          (children[0] ** children[1]).simplify(context)
         else
           self
         end

--- a/lib/keisan/ast/exponent.rb
+++ b/lib/keisan/ast/exponent.rb
@@ -16,6 +16,15 @@ module Keisan
       def blank_value
         1
       end
+
+      def simplify(context = nil)
+        super
+        if children.all? {|child| child.is_a?(ConstantLiteral)}
+          children[0] ** children[1]
+        else
+          self
+        end
+      end
     end
   end
 end

--- a/lib/keisan/ast/exponent.rb
+++ b/lib/keisan/ast/exponent.rb
@@ -19,6 +19,11 @@ module Keisan
 
       def simplify(context = nil)
         super
+
+        if children[1].is_a?(AST::Number) && children[1].value(context) == 1
+          return children[0]
+        end
+
         if children.all? {|child| child.is_a?(ConstantLiteral)}
           children[0] ** children[1]
         else

--- a/lib/keisan/ast/function.rb
+++ b/lib/keisan/ast/function.rb
@@ -46,7 +46,7 @@ module Keisan
       def simplify(context = nil)
         super
         if function_defined?(context) && children.all? {|child| child.is_a?(ConstantLiteral)}
-          ConstantLiteral.from_value(value(context))
+          ConstantLiteral.from_value(value(context)).simplify(context)
         else
           self
         end

--- a/lib/keisan/ast/function.rb
+++ b/lib/keisan/ast/function.rb
@@ -46,7 +46,7 @@ module Keisan
       def simplify(context = nil)
         super
         if function_defined?(context) && children.all? {|child| child.is_a?(ConstantLiteral)}
-          ConstantLiteral.from_value(value)
+          ConstantLiteral.from_value(value(context))
         else
           self
         end

--- a/lib/keisan/ast/number.rb
+++ b/lib/keisan/ast/number.rb
@@ -16,7 +16,7 @@ module Keisan
         when AST::Number
           AST::Number.new(value + other.value)
         else
-          raise TypeError.new("#{other}'s type is invalid, #{other.class}")
+          raise Keisan::Exceptions::TypeError.new("#{other}'s type is invalid, #{other.class}")
         end
       end
 
@@ -27,7 +27,7 @@ module Keisan
         when AST::String
           AST::String.new(other.value * value)
         else
-          raise TypeError.new("#{other}'s type is invalid, #{other.class}")
+          raise Keisan::Exceptions::TypeError.new("#{other}'s type is invalid, #{other.class}")
         end
       end
 
@@ -36,7 +36,7 @@ module Keisan
         when AST::Number
           AST::Number.new(value ** other.value)
         else
-          raise TypeError.new("#{other}'s type is invalid, #{other.class}")
+          raise Keisan::Exceptions::TypeError.new("#{other}'s type is invalid, #{other.class}")
         end
       end
     end

--- a/lib/keisan/ast/number.rb
+++ b/lib/keisan/ast/number.rb
@@ -30,6 +30,15 @@ module Keisan
           raise TypeError.new("#{other}'s type is invalid, #{other.class}")
         end
       end
+
+      def **(other)
+        case other
+        when AST::Number
+          AST::Number.new(value ** other.value)
+        else
+          raise TypeError.new("#{other}'s type is invalid, #{other.class}")
+        end
+      end
     end
   end
 end

--- a/lib/keisan/ast/number.rb
+++ b/lib/keisan/ast/number.rb
@@ -39,6 +39,17 @@ module Keisan
           raise Keisan::Exceptions::TypeError.new("#{other}'s type is invalid, #{other.class}")
         end
       end
+
+      def simplify(context = nil)
+        case number
+        when Rational
+          if number.denominator == 1
+            @number = number.numerator
+          end
+        end
+
+        self
+      end
     end
   end
 end

--- a/lib/keisan/ast/plus.rb
+++ b/lib/keisan/ast/plus.rb
@@ -34,12 +34,16 @@ module Keisan
       def simplify(context = nil)
         super
         constants, non_constants = *children.partition {|child| child.is_a?(ConstantLiteral)}
-        constant = constants.inject(0, &:+)
+        constant = constants.inject(AST::Number.new(0), &:+)
 
         if non_constants.empty?
           constant
         else
-          @children = [constant] + non_constants
+          @children = constant.value == 0 ? [] : [constant]
+          @children += non_constants
+
+          return @children.first if @children.size == 1
+
           self
         end
       end

--- a/lib/keisan/ast/plus.rb
+++ b/lib/keisan/ast/plus.rb
@@ -34,7 +34,7 @@ module Keisan
       def simplify(context = nil)
         super
         constants, non_constants = *children.partition {|child| child.is_a?(ConstantLiteral)}
-        constant = constants.inject(AST::Number.new(0), &:+)
+        constant = constants.inject(AST::Number.new(0), &:+).simplify(context)
 
         if non_constants.empty?
           constant
@@ -42,7 +42,7 @@ module Keisan
           @children = constant.value == 0 ? [] : [constant]
           @children += non_constants
 
-          return @children.first if @children.size == 1
+          return @children.first.simplify(context) if @children.size == 1
 
           self
         end

--- a/lib/keisan/ast/plus.rb
+++ b/lib/keisan/ast/plus.rb
@@ -39,7 +39,7 @@ module Keisan
         if non_constants.empty?
           constant
         else
-          @children = constant.value == 0 ? [] : [constant]
+          @children = constant.value(context) == 0 ? [] : [constant]
           @children += non_constants
 
           return @children.first.simplify(context) if @children.size == 1

--- a/lib/keisan/ast/string.rb
+++ b/lib/keisan/ast/string.rb
@@ -16,7 +16,7 @@ module Keisan
         when AST::String
           AST::String.new(value + other.value)
         else
-          raise TypeError.new("#{other}'s type is invalid, #{other.class}")
+          raise Keisan::Exceptions::TypeError.new("#{other}'s type is invalid, #{other.class}")
         end
       end
     end

--- a/lib/keisan/ast/times.rb
+++ b/lib/keisan/ast/times.rb
@@ -21,12 +21,18 @@ module Keisan
       def simplify(context = nil)
         super
         constants, non_constants = *children.partition {|child| child.is_a?(ConstantLiteral)}
-        constant = constants.inject(1, &:*)
+        constant = constants.inject(AST::Number.new(1), &:*)
+
+        return Keisan::AST::Number.new(0) if constant.value == 0
 
         if non_constants.empty?
           constant
         else
-          @children = [constant] + non_constants
+          @children = constant.value == 1 ? [] : [constant]
+          @children += non_constants
+
+          return @children.first if @children.size == 1
+
           self
         end
       end

--- a/lib/keisan/ast/times.rb
+++ b/lib/keisan/ast/times.rb
@@ -23,12 +23,12 @@ module Keisan
         constants, non_constants = *children.partition {|child| child.is_a?(ConstantLiteral)}
         constant = constants.inject(AST::Number.new(1), &:*).simplify(context)
 
-        return Keisan::AST::Number.new(0) if constant.value == 0
+        return Keisan::AST::Number.new(0) if constant.value(context) == 0
 
         if non_constants.empty?
           constant
         else
-          @children = constant.value == 1 ? [] : [constant]
+          @children = constant.value(context) == 1 ? [] : [constant]
           @children += non_constants
 
           return @children.first.simplify(context) if @children.size == 1

--- a/lib/keisan/ast/times.rb
+++ b/lib/keisan/ast/times.rb
@@ -21,7 +21,7 @@ module Keisan
       def simplify(context = nil)
         super
         constants, non_constants = *children.partition {|child| child.is_a?(ConstantLiteral)}
-        constant = constants.inject(AST::Number.new(1), &:*)
+        constant = constants.inject(AST::Number.new(1), &:*).simplify(context)
 
         return Keisan::AST::Number.new(0) if constant.value == 0
 
@@ -31,7 +31,7 @@ module Keisan
           @children = constant.value == 1 ? [] : [constant]
           @children += non_constants
 
-          return @children.first if @children.size == 1
+          return @children.first.simplify(context) if @children.size == 1
 
           self
         end

--- a/lib/keisan/ast/unary_inverse.rb
+++ b/lib/keisan/ast/unary_inverse.rb
@@ -10,9 +10,10 @@ module Keisan
       end
 
       def simplify(context = nil)
+        @children = [child.simplify(context)]
         case child
         when AST::Number
-          AST::Number.new(Rational(1,child.value(context)))
+          AST::Number.new(Rational(1,child.value(context))).simplify(context)
         else
           super
         end

--- a/lib/keisan/ast/unary_inverse.rb
+++ b/lib/keisan/ast/unary_inverse.rb
@@ -8,6 +8,15 @@ module Keisan
       def to_s
         "(#{child.to_s})**(-1)"
       end
+
+      def simplify(context = nil)
+        case child
+        when AST::Number
+          AST::Number.new(Rational(1,child.value(context)))
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/keisan/ast/unary_minus.rb
+++ b/lib/keisan/ast/unary_minus.rb
@@ -12,7 +12,7 @@ module Keisan
       def simplify(context = nil)
         case child
         when AST::Number
-          AST::Number.new(-child.value(context))
+          AST::Number.new(-child.value(context)).simplify(context)
         else
           super
         end

--- a/lib/keisan/ast/unary_minus.rb
+++ b/lib/keisan/ast/unary_minus.rb
@@ -8,6 +8,15 @@ module Keisan
       def self.symbol
         :"-"
       end
+
+      def simplify(context = nil)
+        case child
+        when AST::Number
+          AST::Number.new(-child.value(context))
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/keisan/ast/unary_operator.rb
+++ b/lib/keisan/ast/unary_operator.rb
@@ -20,6 +20,10 @@ module Keisan
       def to_s
         "#{symbol.to_s}#{child.to_s}"
       end
+
+      def simplify(context = nil)
+        self
+      end
     end
   end
 end

--- a/lib/keisan/ast/unary_plus.rb
+++ b/lib/keisan/ast/unary_plus.rb
@@ -12,7 +12,7 @@ module Keisan
       def simplify(context = nil)
         case child
         when AST::Number
-          AST::Number.new(child.value(context))
+          AST::Number.new(child.value(context)).simplify(context)
         else
           super
         end

--- a/lib/keisan/ast/unary_plus.rb
+++ b/lib/keisan/ast/unary_plus.rb
@@ -8,6 +8,15 @@ module Keisan
       def to_s
         :"+"
       end
+
+      def simplify(context = nil)
+        case child
+        when AST::Number
+          AST::Number.new(child.value(context))
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/keisan/ast/variable.rb
+++ b/lib/keisan/ast/variable.rb
@@ -28,7 +28,7 @@ module Keisan
       def simplify(context = nil)
         context ||= Keisan::Context.new
         if context.has_variable?(name)
-          ConstantLiteral.from_value(context.variable(name))
+          ConstantLiteral.from_value(context.variable(name)).simplify(context)
         else
           self
         end

--- a/lib/keisan/ast/variable.rb
+++ b/lib/keisan/ast/variable.rb
@@ -24,6 +24,15 @@ module Keisan
       def to_s
         name.to_s
       end
+
+      def simplify(context = nil)
+        context ||= Keisan::Context.new
+        if context.has_variable?(name)
+          ConstantLiteral.from_value(context.variable(name))
+        else
+          self
+        end
+      end
     end
   end
 end

--- a/lib/keisan/exceptions.rb
+++ b/lib/keisan/exceptions.rb
@@ -16,5 +16,6 @@ module Keisan
     class UndefinedVariableError < StandardError; end
     class UnmodifiableError < StandardError; end
     class InvalidExpression < StandardError; end
+    class TypeError < StandardError; end
   end
 end

--- a/spec/keisan/ast/node_spec.rb
+++ b/spec/keisan/ast/node_spec.rb
@@ -95,6 +95,29 @@ RSpec.describe Keisan::AST::Node do
       end
     end
 
+    context "simplifying with zero" do
+      it "sets the term to 0" do
+        ast = Keisan::AST.parse("1 + 0*x")
+        expect(ast.simplified).to be_a(Keisan::AST::Number)
+        expect(ast.simplified.value).to eq 1
+
+        ast = Keisan::AST.parse("12*x + (1-1)*y")
+        expect(ast.simplified.to_s).to eq "12*x"
+      end
+    end
+
+    context "simplifying with 1" do
+      it "removes it from products" do
+        ast = Keisan::AST.parse("15 + 1*x*((5-3)/2)")
+        expect(ast.simplified.to_s).to eq "15+x"
+      end
+
+      it "is removed from top of exponents" do
+        ast = Keisan::AST.parse("x + sin(y)**(5+x*y*(2-1-1)-4)")
+        expect(ast.simplified.to_s).to eq "x+sin(y)"
+      end
+    end
+
     context "numbers and variables" do
       it "simplifies the expression, leaving the varible alone" do
         ast = Keisan::AST.parse("10 + x + 5 + y")

--- a/spec/keisan/ast/node_spec.rb
+++ b/spec/keisan/ast/node_spec.rb
@@ -116,6 +116,11 @@ RSpec.describe Keisan::AST::Node do
         ast = Keisan::AST.parse("x + sin(y)**(5+x*y*(2-1-1)-4)")
         expect(ast.simplified.to_s).to eq "x+sin(y)"
       end
+
+      it "removes from denominators" do
+        ast = Keisan::AST.parse("y/(0*x+1)")
+        expect(ast.simplified.to_s).to eq "y"
+      end
     end
 
     context "numbers and variables" do

--- a/spec/keisan/ast/node_spec.rb
+++ b/spec/keisan/ast/node_spec.rb
@@ -73,7 +73,25 @@ RSpec.describe Keisan::AST::Node do
         ast_simple = ast.simplified
         expect(ast_simple).not_to eq(ast)
         expect(ast_simple).to be_a(Keisan::AST::Number)
-        expect(ast_simple.value).to eq 21
+        expect(ast_simple.value).to eq 27
+      end
+    end
+
+    context "with prescribed variables" do
+      it "fills the values in" do
+        ast = Keisan::AST.parse("x**2 + y**2")
+        ast_simple = ast.simplified(Keisan::Context.new.tap {|c|
+          c.register_variable!("x", 3)
+        })
+        expect(ast_simple).to be_a(Keisan::AST::Plus)
+        expect(ast_simple.to_s).to eq "9+(y**2)"
+
+        ast_very_simple = ast.simplified(Keisan::Context.new.tap {|c|
+          c.register_variable!("x", 3)
+          c.register_variable!("y", 4)
+        })
+        expect(ast_very_simple).to be_a(Keisan::AST::Number)
+        expect(ast_very_simple.value).to eq 25
       end
     end
 

--- a/spec/keisan/ast/node_spec.rb
+++ b/spec/keisan/ast/node_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Keisan::AST::Node do
         expect(ast_simple).to be_a(Keisan::AST::Number)
         expect(ast_simple.value).to eq 9
 
-        ast = Keisan::AST.parse("3 * (2+5)")
+        ast = Keisan::AST.parse("3 * (2**2+5)")
         ast_simple = ast.simplified
         expect(ast_simple).not_to eq(ast)
         expect(ast_simple).to be_a(Keisan::AST::Number)


### PR DESCRIPTION
Some basic simplifications for special handling of 0 and 1.

- Products with a 0 factor become 0
- Products have 1 terms dropped
- Sums have 0 terms dropped
- `a**b` for b = 1 are reduced to `a`
- Fractions with 1 in denominator are reduced to just the numerator