### PR TITLE
Expression functions

### DIFF
--- a/lib/keisan/ast.rb
+++ b/lib/keisan/ast.rb
@@ -10,11 +10,19 @@ module KeisanNumeric
   def to_node
     Keisan::AST::Number.new(self)
   end
+
+  def value(context = nil)
+    self
+  end
 end
 
 module KeisanString
   def to_node
     Keisan::AST::String.new(self)
+  end
+
+  def value(context = nil)
+    self
   end
 end
 
@@ -22,11 +30,19 @@ module KeisanTrueClass
   def to_node
     Keisan::AST::Boolean.new(true)
   end
+
+  def value(context = nil)
+    self
+  end
 end
 
 module KeisanFalseClass
   def to_node
     Keisan::AST::Boolean.new(false)
+  end
+
+  def value(context = nil)
+    self
   end
 end
 
@@ -34,11 +50,19 @@ module KeisanNilClass
   def to_node
     Keisan::AST::Null.new
   end
+
+  def value(context = nil)
+    self
+  end
 end
 
 module KeisanArray
   def to_node
     Keisan::AST::List.new(map {|n| n.to_node})
+  end
+
+  def value(context = nil)
+    self
   end
 end
 

--- a/lib/keisan/ast/assignment.rb
+++ b/lib/keisan/ast/assignment.rb
@@ -66,8 +66,7 @@ module Keisan
           )
         )
 
-        # Return the function itself
-        lhs
+        rhs
       end
     end
   end

--- a/lib/keisan/ast/assignment.rb
+++ b/lib/keisan/ast/assignment.rb
@@ -32,6 +32,7 @@ module Keisan
 
         rhs_value = rhs.value(context)
         context.register_variable!(lhs.name, rhs_value)
+        # Return the variable assigned value
         rhs
       end
 
@@ -61,11 +62,12 @@ module Keisan
             lhs.name,
             argument_names,
             rhs,
-            function_definition_context
+            context.transient_definitions
           )
         )
 
-        rhs
+        # Return the function itself
+        lhs
       end
     end
   end

--- a/lib/keisan/ast/function.rb
+++ b/lib/keisan/ast/function.rb
@@ -47,7 +47,7 @@ module Keisan
         if function_defined?(context)
           function_from_context(context).evaluate(self, context)
         else
-          @children = children.map {|child| child.evaluate(context)}
+          @children = children.map {|child| child.evaluate(context).to_node}
           self
         end
       end
@@ -58,7 +58,7 @@ module Keisan
         if function_defined?(context)
           function_from_context(context).simplify(self, context)
         else
-          @children = children.map {|child| child.simplify(context)}
+          @children = children.map {|child| child.simplify(context).to_node}
           self
         end
       end

--- a/lib/keisan/ast/node.rb
+++ b/lib/keisan/ast/node.rb
@@ -80,7 +80,7 @@ module Keisan
       end
 
       def !
-        AST::LogicalNot.new(self)
+        AST::UnaryLogicalNot.new(self)
       end
 
       def ~

--- a/lib/keisan/ast/parent.rb
+++ b/lib/keisan/ast/parent.rb
@@ -4,7 +4,7 @@ module Keisan
       attr_reader :children
 
       def initialize(children = [])
-        children = Array.wrap(children)
+        children = Array.wrap(children).map(&:to_node)
         unless children.is_a?(Array) && children.all? {|children| children.is_a?(Node)}
           raise Keisan::Exceptions::InternalError.new
         end

--- a/lib/keisan/ast/plus.rb
+++ b/lib/keisan/ast/plus.rb
@@ -24,7 +24,7 @@ module Keisan
           children_values.inject([], &:+)
         else
           children_values.inject(0, &:+)
-        end
+        end.to_node.value(context)
       end
 
       def evaluate(context = nil)

--- a/lib/keisan/ast/unary_operator.rb
+++ b/lib/keisan/ast/unary_operator.rb
@@ -3,7 +3,7 @@ module Keisan
     class UnaryOperator < Operator
       def initialize(children = [])
         children = Array.wrap(children)
-        super
+        super(children)
         if children.count != 1
           raise Keisan::Exceptions::ASTError.new("Unary operator takes has a single child")
         end

--- a/lib/keisan/ast/variable.rb
+++ b/lib/keisan/ast/variable.rb
@@ -28,7 +28,13 @@ module Keisan
       def evaluate(context = nil)
         context ||= Keisan::Context.new
         if context.has_variable?(name)
-          context.variable(name).to_node.evaluate(context)
+          variable = context.variable(name)
+          # The variable might just be a variable, i.e. probably in function definition
+          if variable.is_a?(AST::Node)
+            variable.is_a?(AST::Variable) ? variable : variable.evaluate(context)
+          else
+            variable
+          end
         else
           self
         end

--- a/lib/keisan/context.rb
+++ b/lib/keisan/context.rb
@@ -16,12 +16,14 @@ module Keisan
     # current context, but such that variable/function definitions can be persisted in
     # the calculator.
     def spawn_child(definitions: {}, transient: false)
-      child = self.class.new(parent: self, allow_recursive: allow_recursive)
+      child = pure_child
 
       definitions.each do |name, value|
         case value
         when Proc
           child.register_function!(name, value)
+        when Keisan::Functions::ProcFunction
+          child.register_function!(name, value.function_proc)
         else
           child.register_variable!(name, value)
         end
@@ -85,6 +87,10 @@ module Keisan
 
     def set_transient!
       @transient = true
+    end
+
+    def pure_child
+      self.class.new(parent: self, allow_recursive: allow_recursive)
     end
   end
 end

--- a/lib/keisan/context.rb
+++ b/lib/keisan/context.rb
@@ -11,7 +11,7 @@ module Keisan
     end
 
     def spawn_child(definitions: {}, transient: false)
-      child = Context.new(parent: self, allow_recursive: allow_recursive)
+      child = self.class.new(parent: self, allow_recursive: allow_recursive)
 
       definitions.each do |name, value|
         case value

--- a/lib/keisan/context.rb
+++ b/lib/keisan/context.rb
@@ -10,6 +10,11 @@ module Keisan
       @allow_recursive   = allow_recursive
     end
 
+    # A transient context does not persist variables and functions in this context, but
+    # rather store them one level higher in the parent context.  When evaluating a string,
+    # the entire operation is done in a transient context that is unique from the calculators
+    # current context, but such that variable/function definitions can be persisted in
+    # the calculator.
     def spawn_child(definitions: {}, transient: false)
       child = self.class.new(parent: self, allow_recursive: allow_recursive)
 

--- a/lib/keisan/context.rb
+++ b/lib/keisan/context.rb
@@ -31,6 +31,20 @@ module Keisan
       child
     end
 
+    def transient_definitions
+      return {} unless @transient
+      parent_definitions = @parent.present? ? @parent.transient_definitions : {}
+      parent_definitions.merge(
+        @variable_registry.locals
+      ).merge(
+        @function_registry.locals
+      )
+    end
+
+    def transient?
+      !!@transient
+    end
+
     def variable(name)
       @variable_registry[name.to_s]
     end

--- a/lib/keisan/evaluator.rb
+++ b/lib/keisan/evaluator.rb
@@ -14,7 +14,7 @@ module Keisan
       case ast
       when Keisan::AST::Assignment
         if ast.children.first.is_a?(Keisan::AST::Variable)
-          context.variable(ast.children.first.name)
+          context.variable(ast.children.first.name).value
         end
       else
         evaluation.value(context)

--- a/lib/keisan/function_definition_context.rb
+++ b/lib/keisan/function_definition_context.rb
@@ -1,34 +1,28 @@
 module Keisan
   class FunctionDefinitionContext < Context
-    def initialize(parent:, arguments:)
-      super(parent: parent)
+    def initialize(parent:, arguments:, allow_recursive: false, arguments_context: nil)
+      super(parent: parent, allow_recursive: allow_recursive)
       @arguments = Set.new(arguments)
-      @arguments_context = Context.new
+      @arguments_context = arguments_context || Context.new
       set_transient!
     end
 
     def variable(name)
-      if @arguments.member?(name)
-        @arguments_context.variable(name)
-      else
-        super
-      end
+      @arguments.member?(name) ? @arguments_context.variable(name) : super
     end
 
     def has_variable?(name)
-      if @arguments.member?(name)
-        @arguments_context.has_variable?(name)
-      else
-        super
-      end
+      @arguments.member?(name) ? @arguments_context.has_variable?(name) : super
     end
 
     def register_variable!(name, value)
-      if @arguments.member?(name)
-        @arguments_context.register_variable!(name, value)
-      else
-        super
-      end
+      @arguments.member?(name) ? @arguments_context.register_variable!(name, value) : super
+    end
+
+    protected
+
+    def pure_child
+      self.class.new(parent: self, arguments: @arguments, arguments_context: @arguments_context, allow_recursive: allow_recursive)
     end
   end
 end

--- a/lib/keisan/functions/default_registry.rb
+++ b/lib/keisan/functions/default_registry.rb
@@ -30,6 +30,7 @@ module Keisan
           registry.register!(
             method,
             Proc.new {|*args|
+              args = args.map(&:value)
               Math.send(method, *args)
             },
             force: true

--- a/lib/keisan/functions/if.rb
+++ b/lib/keisan/functions/if.rb
@@ -27,17 +27,8 @@ module Keisan
         bool = ast_function.children[0].evaluate(context)
 
         if bool.is_a?(Keisan::AST::Boolean)
-          if bool.value
-            ast_function.children[1].evaluate(context)
-          else
-            ast_function.children[2].to_node.evaluate(context)
-          end
-        else
-          ast_function
-        end
-
-        if ast_function.children.all? {|child| child.well_defined?(context)}
-          value(ast_function, context).to_node.evaluate(context)
+          node = bool.value ? ast_function.children[1] : ast_function.children[2]
+          node.to_node.evaluate(context)
         else
           ast_function
         end
@@ -49,7 +40,7 @@ module Keisan
 
         if bool.is_a?(Keisan::AST::Boolean)
           if bool.value
-            ast_function.children[1].simplify(context)
+            ast_function.children[1].to_node.simplify(context)
           else
             ast_function.children[2].to_node.simplify(context)
           end

--- a/lib/keisan/functions/registry.rb
+++ b/lib/keisan/functions/registry.rb
@@ -22,6 +22,10 @@ module Keisan
         raise Keisan::Exceptions::UndefinedFunctionError.new name
       end
 
+      def locals
+        @hash
+      end
+
       def has?(name)
         !!self[name]
       rescue Keisan::Exceptions::UndefinedFunctionError

--- a/lib/keisan/variables/registry.rb
+++ b/lib/keisan/variables/registry.rb
@@ -33,7 +33,7 @@ module Keisan
         if !force && @use_defaults && default_registry.has_name?(name)
           raise Keisan::Exceptions::UnmodifiableError.new("Cannot overwrite default variable")
         end
-        self[name.to_s] = value
+        self[name.to_s] = value.to_node
       end
 
       protected

--- a/lib/keisan/variables/registry.rb
+++ b/lib/keisan/variables/registry.rb
@@ -22,8 +22,12 @@ module Keisan
         raise Keisan::Exceptions::UndefinedVariableError.new name
       end
 
+      def locals
+        @hash
+      end
+
       def has?(name)
-        !!self[name]
+        !self[name].nil?
       rescue Keisan::Exceptions::UndefinedVariableError
         false
       end

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -106,9 +106,13 @@ RSpec.describe Keisan::Calculator do
     end
 
     context "with definitions" do
-      it "raises an error if there is an undefined variable" do
-        calculator.evaluate("f(x) = n*x", n: 10)
-        expect(calculator.evaluate("f(3)")).to eq 30
+      it "local variables are evaluated, i.e. only function arguments remain variables" do
+        calculator.evaluate("a = 2")
+        calculator.evaluate("f(x) = a*n*x + g(x)", n: 10, g: Proc.new {|x| x**2})
+        expect(calculator.evaluate("f(3)")).to eq (60 + 3**2)
+        calculator.evaluate("a = 3")
+        calculator.evaluate("g(x) = 0")
+        expect(calculator.evaluate("f(3)")).to eq (60 + 3**2)
       end
     end
 

--- a/spec/keisan/context_spec.rb
+++ b/spec/keisan/context_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Keisan::Context do
 
     my_context.register_variable!("x", 2)
     my_context.register_function!("f", Proc.new {|x| x**2})
-    expect(my_context.variable("x")).to eq 2
-    expect(my_context.function("f").call(nil, 3)).to eq 9
+    expect(my_context.variable("x").value).to eq 2
+    expect(my_context.function("f").call(nil, 3).value).to eq 9
   end
 
   it "has default variables and functions" do
     my_context = described_class.new
 
-    expect(my_context.variable("PI")).to eq Math::PI
+    expect(my_context.variable("PI").value).to eq Math::PI
     expect(my_context.function("sin")).to be_a(Keisan::Function)
   end
 
@@ -25,8 +25,8 @@ RSpec.describe Keisan::Context do
       my_context.register_function!("f", Proc.new {|x| x**2})
 
       child_context = my_context.spawn_child
-      expect(child_context.variable("x")).to eq 2
-      expect(child_context.function("f").call(nil, 3)).to eq 9
+      expect(child_context.variable("x").value).to eq 2
+      expect(child_context.function("f").call(nil, 3).value).to eq 9
     end
 
     it "can shadow parent" do
@@ -41,15 +41,15 @@ RSpec.describe Keisan::Context do
       child_context.register_variable!("x", 5)
       child_context.register_function!("f", Proc.new {|x| x**3})
 
-      expect(my_context.variable("x")).to eq 2
-      expect(my_context.variable("y")).to eq 7
-      expect(my_context.function("f").call(nil, 2)).to eq 4
-      expect(my_context.function("g").call(nil, 2)).to eq 1
+      expect(my_context.variable("x").value).to eq 2
+      expect(my_context.variable("y").value).to eq 7
+      expect(my_context.function("f").call(nil, 2).value).to eq 4
+      expect(my_context.function("g").call(nil, 2).value).to eq 1
 
-      expect(child_context.variable("x")).to eq 5
-      expect(child_context.variable("y")).to eq 7
-      expect(child_context.function("f").call(nil, 2)).to eq 8
-      expect(child_context.function("g").call(nil, 2)).to eq 1
+      expect(child_context.variable("x").value).to eq 5
+      expect(child_context.variable("y").value).to eq 7
+      expect(child_context.function("f").call(nil, 2).value).to eq 8
+      expect(child_context.function("g").call(nil, 2).value).to eq 1
     end
   end
 
@@ -121,8 +121,8 @@ RSpec.describe Keisan::Context do
       my_context.register_function!("f", Proc.new {|x| x**2})
 
       child_context = my_context.spawn_child(transient: true)
-      expect(child_context.variable("x")).to eq 2
-      expect(child_context.function("f").call(nil, 3)).to eq 9
+      expect(child_context.variable("x").value).to eq 2
+      expect(child_context.function("f").call(nil, 3).value).to eq 9
     end
 
     it "is transient so all definitions bubble up to parent context" do
@@ -133,10 +133,10 @@ RSpec.describe Keisan::Context do
       my_context.register_function!("f", Proc.new {|x| x**2})
       my_context.register_function!("g", Proc.new {|x| x-1})
 
-      expect(my_context.variable("x")).to eq 2
-      expect(my_context.variable("y")).to eq 7
-      expect(my_context.function("f").call(nil, 2)).to eq 4
-      expect(my_context.function("g").call(nil, 2)).to eq 1
+      expect(my_context.variable("x").value).to eq 2
+      expect(my_context.variable("y").value).to eq 7
+      expect(my_context.function("f").call(nil, 2).value).to eq 4
+      expect(my_context.function("g").call(nil, 2).value).to eq 1
 
       child_context = my_context.spawn_child(transient: true)
 
@@ -149,15 +149,15 @@ RSpec.describe Keisan::Context do
       Keisan::Calculator.new(context: child_context).evaluate("g(x) = 123*x")
 
       # Overriden by transient child!
-      expect(my_context.variable("x")).to eq 5
-      expect(my_context.variable("y")).to eq 11
-      expect(my_context.function("f").call(nil, 2)).to eq 8
-      expect(my_context.function("g").call(nil, 2)).to eq 246
+      expect(my_context.variable("x").value).to eq 5
+      expect(my_context.variable("y").value).to eq 11
+      expect(my_context.function("f").call(nil, 2).value).to eq 8
+      expect(my_context.function("g").call(nil, 2).value).to eq 246
 
-      expect(child_context.variable("x")).to eq 5
-      expect(child_context.variable("y")).to eq 11
-      expect(child_context.function("f").call(nil, 2)).to eq 8
-      expect(child_context.function("g").call(nil, 2)).to eq 246
+      expect(child_context.variable("x").value).to eq 5
+      expect(child_context.variable("y").value).to eq 11
+      expect(child_context.function("f").call(nil, 2).value).to eq 8
+      expect(child_context.function("g").call(nil, 2).value).to eq 246
     end
 
     it "stores transient definitions" do

--- a/spec/keisan/context_spec.rb
+++ b/spec/keisan/context_spec.rb
@@ -139,6 +139,10 @@ RSpec.describe Keisan::Context do
       expect(my_context.function("g").call(nil, 2)).to eq 1
 
       child_context = my_context.spawn_child(transient: true)
+
+      expect(my_context.transient?).to be false
+      expect(child_context.transient?).to be true
+
       child_context.register_variable!("x", 5)
       child_context.register_function!("f", Proc.new {|x| x**3})
       Keisan::Calculator.new(context: child_context).evaluate("y = 11")
@@ -154,6 +158,15 @@ RSpec.describe Keisan::Context do
       expect(child_context.variable("y")).to eq 11
       expect(child_context.function("f").call(nil, 2)).to eq 8
       expect(child_context.function("g").call(nil, 2)).to eq 246
+    end
+
+    it "stores transient definitions" do
+      my_context     = described_class.new
+      child_context  = my_context.spawn_child(definitions: {x: 15, f: Proc.new {|x| x**2}}, transient: true)
+      child2_context = child_context.spawn_child(definitions: {y: 32, g: Proc.new {|x| x**3}}, transient: true)
+
+      expect(child_context.transient_definitions.keys).to match_array(["x", "f"])
+      expect(child2_context.transient_definitions.keys).to match_array(["x", "y", "f", "g"])
     end
   end
 end

--- a/spec/keisan/context_spec.rb
+++ b/spec/keisan/context_spec.rb
@@ -41,6 +41,11 @@ RSpec.describe Keisan::Context do
       child_context.register_variable!("x", 5)
       child_context.register_function!("f", Proc.new {|x| x**3})
 
+      expect(my_context.variable("x")).to eq 2
+      expect(my_context.variable("y")).to eq 7
+      expect(my_context.function("f").call(nil, 2)).to eq 4
+      expect(my_context.function("g").call(nil, 2)).to eq 1
+
       expect(child_context.variable("x")).to eq 5
       expect(child_context.variable("y")).to eq 7
       expect(child_context.function("f").call(nil, 2)).to eq 8

--- a/spec/keisan/default_functions_spec.rb
+++ b/spec/keisan/default_functions_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Keisan::Functions::DefaultRegistry do
   let(:registry) { described_class.registry }
   it "contains correct functions" do
     expect(registry["sin"].name).to eq "sin"
-    expect(registry["sin"].call(nil, 1)).to eq Math.sin(1)
+    expect(registry["sin"].call(nil, 1).value).to eq Math.sin(1)
   end
 
   it "is unmodifiable" do
@@ -14,13 +14,13 @@ RSpec.describe Keisan::Functions::DefaultRegistry do
   context "array methods" do
     it "works as expected" do
       expect(registry["min"].name).to eq "min"
-      expect(registry["min"].call(nil, [-4, -1, 1, 2])).to eq -4
+      expect(registry["min"].call(nil, [-4, -1, 1, 2]).value).to eq -4
 
       expect(registry["max"].name).to eq "max"
-      expect(registry["max"].call(nil, [-4, -1, 1, 2])).to eq 2
+      expect(registry["max"].call(nil, [-4, -1, 1, 2]).value).to eq 2
 
       expect(registry["size"].name).to eq "size"
-      expect(registry["size"].call(nil, [-4, -1, 1, 2])).to eq 4
+      expect(registry["size"].call(nil, [-4, -1, 1, 2]).value).to eq 4
 
       expect(Keisan::Calculator.new.evaluate("a[size(a)-1]", a: [1, 3, 5, 7])).to eq 7
     end

--- a/spec/keisan/default_variables_spec.rb
+++ b/spec/keisan/default_variables_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Keisan::Variables::DefaultRegistry do
   let(:registry) { described_class.registry }
 
   it "contains correct variables" do
-    expect(registry["PI"]).to eq Math::PI
-    expect(registry["E"]).to eq Math::E
-    expect(registry["I"]).to eq Complex(0,1)
+    expect(registry["PI"].value).to eq Math::PI
+    expect(registry["E"].value).to eq Math::E
+    expect(registry["I"].value).to eq Complex(0,1)
   end
 
   it "is unmodifiable" do

--- a/spec/keisan/functions/proc_function_spec.rb
+++ b/spec/keisan/functions/proc_function_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Keisan::Functions::ProcFunction do
   it "can be initialized from a proc" do
     function = described_class.new("test", Proc.new {|x,y| x + 3*y})
     expect(function.name).to eq "test"
-    expect(function.call(nil,2,6)).to eq 2 + 3*6
+    expect(function.call(nil,2,6).value).to eq 2 + 3*6
   end
 
   it "must be a proc" do

--- a/spec/keisan/functions/registry_spec.rb
+++ b/spec/keisan/functions/registry_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe Keisan::Functions::Registry do
     it "retrieves default methods" do
       expect{registry["sin"]}.not_to raise_error
       expect(registry["sin"].name).to eq "sin"
-      expect(registry["sin"].call(nil, 0)).to eq 0
+      expect(registry["sin"].call(nil, 0).value).to eq 0
     end
 
     it "can store and retrieve methods" do
       registry.register!("test", Proc.new {|x,y| 2*x + y})
       expect(registry["test"].name).to eq "test"
-      expect(registry["test"].call(nil, 3,5)).to eq 2*3 + 5
+      expect(registry["test"].call(nil, 3,5).value).to eq 2*3 + 5
     end
   end
 
@@ -42,17 +42,17 @@ RSpec.describe Keisan::Functions::Registry do
 
     it "gets function from the parent" do
       expect(registry["parent_function"].name).to eq "parent_function"
-      expect(registry["parent_function"].call(nil)).to eq 5
+      expect(registry["parent_function"].call(nil).value).to eq 5
     end
 
     it "can shadow parent functions" do
       registry.register!("parent_function", Proc.new { 11 })
 
       expect(registry["parent_function"].name).to eq "parent_function"
-      expect(registry["parent_function"].call(nil)).to eq 11
+      expect(registry["parent_function"].call(nil).value).to eq 11
 
       expect(parent_registry["parent_function"].name).to eq "parent_function"
-      expect(parent_registry["parent_function"].call(nil)).to eq 5
+      expect(parent_registry["parent_function"].call(nil).value).to eq 5
     end
   end
 end

--- a/spec/keisan/variables/registry_spec.rb
+++ b/spec/keisan/variables/registry_spec.rb
@@ -12,21 +12,21 @@ RSpec.describe Keisan::Variables::Registry do
     end
 
     it "retrieves default variables" do
-      expect(registry["PI"]).to eq Math::PI
-      expect(registry["E"]).to eq Math::E
-      expect(registry["I"]).to eq Complex(0,1)
+      expect(registry["PI"].value).to eq Math::PI
+      expect(registry["E"].value).to eq Math::E
+      expect(registry["I"].value).to eq Complex(0,1)
     end
 
     it "can store and retrieve variables" do
       registry.register!("x", 4)
-      expect(registry["x"]).to eq 4
+      expect(registry["x"].value).to eq 4
     end
   end
 
   context "when not using defaults" do
     let(:use_defaults) { false }
     it "raises error when getting a default variable" do
-      expect{registry["PI"]}.to raise_error(Keisan::Exceptions::UndefinedVariableError)
+      expect{registry["PI"].value}.to raise_error(Keisan::Exceptions::UndefinedVariableError)
     end
   end
 
@@ -40,14 +40,14 @@ RSpec.describe Keisan::Variables::Registry do
     let(:parent) { parent_registry }
 
     it "gets variable from the parent" do
-      expect(registry["x"]).to eq 5
+      expect(registry["x"].value).to eq 5
     end
 
     it "can shadow parent variables" do
       registry.register!("x", 11)
 
-      expect(registry["x"]).to eq 11
-      expect(parent_registry["x"]).to eq 5
+      expect(registry["x"].value).to eq 11
+      expect(parent_registry["x"].value).to eq 5
     end
   end
 end


### PR DESCRIPTION
With these changes, function definitions are now stored internally correctly using the expressions AST as opposed to lambdas/procs.  This will allow lazy evaluation for operations like differentiation to work with user defined functions.