### PR TITLE
Expression function derivative

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,15 @@ calculator.evaluate("replace(diff(4*x**2, x), x, 3)")
 #=> 24
 ```
 
+This also works intelligently with user defined functions.
+
+```ruby
+calculator = Keisan::Calculator.new
+calculator.evaluate("f(x, y) = x**2 + y")
+calculator.evaluate("replace(diff(f(2*t, t+1), t), t, 3)")
+#=> 8*3+1
+```
+
 ### Adding custom variables and functions
 
 The `Keisan::Calculator` class has a single `Keisan::Context` object in its `context` attribute.  This class is used to store local variables and functions.  These can be stored using either the `define_variable!` or `define_function!` methods, or by using the assignment operator `=` in an expression that is evaluated.  As an example of pre-defining some variables and functions, see the following

--- a/lib/keisan/ast/exponent.rb
+++ b/lib/keisan/ast/exponent.rb
@@ -58,7 +58,7 @@ module Keisan
 
         # Special simple case where exponent is a pure number
         if exponent.is_a?(AST::Number)
-          return (exponent * base ** (exponent -1)).simplify(context)
+          return (exponent * base.differentiate(variable, context) * base ** (exponent -1)).simplify(context)
         end
 
         base_diff     = base.differentiate(variable, context)

--- a/lib/keisan/ast/function.rb
+++ b/lib/keisan/ast/function.rb
@@ -68,10 +68,14 @@ module Keisan
       end
 
       def differentiate(variable, context = nil)
+        function = function_from_context(context)
+        function.differentiate(self, variable, context)
+
+      rescue Keisan::Exceptions::UndefinedFunctionError, Keisan::Exceptions::NotImplementedError
         unless unbound_variables(context).include?(variable.name)
           return AST::Number.new(0)
         end
-        # Do not know how to differentiate a function in general, so leave as derivative
+
         AST::Function.new([self, variable], "diff")
       end
     end

--- a/lib/keisan/function.rb
+++ b/lib/keisan/function.rb
@@ -17,5 +17,9 @@ module Keisan
     def simplify(ast_function, context = nil)
       raise Keisan::Exceptions::NotImplementedError.new
     end
+
+    def differentiate(ast_function, variable, context = nil)
+      raise Keisan::Exceptions::NotImplementedError.new
+    end
   end
 end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "README.md" do
       digest = Digest::SHA256.hexdigest(content)
 
       # cat README.md | sha256sum
-      if digest != "7e2dbf3481986ee1b8d697ef7c7f70c654c839b41096f50b71ddb7fc0d6a8ef3"
+      if digest != "afe979dee328947080f88e5917e6a13fc95584de7d32a946ecac23f6e9cad902"
         raise "Invalid README file detected: #{digest}"
       end
 


### PR DESCRIPTION
Issue #25 

Implements chain rule for user defined functions.  This is possible because the use of `ExpressionFunction` means that user defined functions remember their exact definition, so it is possible to calculate derivatives based on this.  This is what it looks like in use:

```ruby
calculator = Keisan::Calculator.new
calculator.evaluate("f(x, y) = x**2 + y")
calculator.evaluate("replace(diff(f(2*t, t+1), t), t, 3)")
#=> 25
```