### PR TITLE
Calculator simplify method

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,39 @@ Or install it yourself as:
 
 ### Calculator class
 
-The functionality of `keisan` can be demonstrated by using the `Keisan::Calculator` class.  The `evaluate` method evaluates an expression by parsing it into an abstract syntax tree (AST), then evaluating any member functions/variables given.
+The functionality of `keisan` can be demonstrated by using the `Keisan::Calculator` class.  The `evaluate` method evaluates an expression by parsing it into an abstract syntax tree (AST), then evaluating any member functions/variables given.  There is also a `simplify` method that allows undefined variables and functions to exist, and will just return a string representation of the expression as simplified as it can.
 
 ```ruby
 calculator = Keisan::Calculator.new
 calculator.evaluate("15 + 2 * (1 + 3)")
 #=> 23
+calculator.simplify("1*(0*2+x*g(t))")
+#=> "x*g(t)"
+```
+
+For users who want access to the parsed abstract syntax tree, you can use the `ast` method to parse any given expression.
+
+```ruby
+calculator = Keisan::Calculator.new
+ast = calculator.ast("x**2+1")
+ast.to_s
+#=> "(x**2)+1"
+ast.class
+#=> Keisan::AST::Plus
+ast.children[0].class
+#=> Keisan::AST::Exponent
+ast.children[0].children[0].class
+#=> Keisan::AST::Variable
+ast.children[0].children[0].name
+#=> "x"
+ast.children[0].children[1].class
+#=> Keisan::AST::Number
+ast.children[0].children[1].value
+#=> 2
+ast.children[1].class
+#=> Keisan::AST::Number
+ast.children[1].value
+#=> 1
 ```
 
 ##### Specifying variables

--- a/README.md
+++ b/README.md
@@ -300,8 +300,10 @@ This also works intelligently with user defined functions.
 ```ruby
 calculator = Keisan::Calculator.new
 calculator.evaluate("f(x, y) = x**2 + y")
+calculator.simplify("diff(f(2*t, t+1), t)")
+#=> "1+(8*t)"
 calculator.evaluate("replace(diff(f(2*t, t+1), t), t, 3)")
-#=> 8*3+1
+#=> 1+8*3
 ```
 
 ### Adding custom variables and functions

--- a/lib/keisan/calculator.rb
+++ b/lib/keisan/calculator.rb
@@ -14,6 +14,10 @@ module Keisan
       Evaluator.new(self).simplify(expression, definitions)
     end
 
+    def ast(expression)
+      Evaluator.new(self).ast(expression)
+    end
+
     def define_variable!(name, value)
       context.register_variable!(name, value)
     end

--- a/lib/keisan/calculator.rb
+++ b/lib/keisan/calculator.rb
@@ -10,6 +10,10 @@ module Keisan
       Evaluator.new(self).evaluate(expression, definitions)
     end
 
+    def simplify(expression, definitions = {})
+      Evaluator.new(self).simplify(expression, definitions)
+    end
+
     def define_variable!(name, value)
       context.register_variable!(name, value)
     end

--- a/lib/keisan/evaluator.rb
+++ b/lib/keisan/evaluator.rb
@@ -20,5 +20,13 @@ module Keisan
         evaluation.value(context)
       end
     end
+
+    def simplify(expression, definitions = {})
+      context = calculator.context.spawn_child(definitions: definitions, transient: true)
+      ast = Keisan::AST.parse(expression)
+      simplification = ast.simplify(context)
+
+      simplification.to_s
+    end
   end
 end

--- a/lib/keisan/evaluator.rb
+++ b/lib/keisan/evaluator.rb
@@ -28,5 +28,9 @@ module Keisan
 
       simplification.to_s
     end
+
+    def ast(expression)
+      Keisan::AST.parse(expression)
+    end
   end
 end

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -42,6 +42,22 @@ RSpec.describe Keisan::Calculator do
     end
   end
 
+  describe "#ast" do
+    it "returns the abstract syntax tree parsed from the expression" do
+      ast = calculator.ast("x**2+1")
+      expect(ast).to be_a(Keisan::AST::Plus)
+
+      expect(ast.children[0]).to be_a(Keisan::AST::Exponent)
+      expect(ast.children[0].children[0]).to be_a(Keisan::AST::Variable)
+      expect(ast.children[0].children[0].name).to eq "x"
+      expect(ast.children[0].children[1]).to be_a(Keisan::AST::Number)
+      expect(ast.children[0].children[1].value).to eq 2
+
+      expect(ast.children[1]).to be_a(Keisan::AST::Number)
+      expect(ast.children[1].value).to eq 1
+    end
+  end
+
   describe "defining variables and functions" do
     it "saves them in the calculators context" do
       calculator.define_variable!("x", 5)

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe Keisan::Calculator do
     end
   end
 
+  describe "#simplify" do
+    it "allows for undefined variables to still exist and returns a string representation of the expression" do
+      expect{calculator.evaluate("0*x+1")}.to raise_error(Keisan::Exceptions::UndefinedVariableError)
+      expect(calculator.simplify("0*x+1")).to eq "1"
+    end
+  end
+
   describe "defining variables and functions" do
     it "saves them in the calculators context" do
       calculator.define_variable!("x", 5)

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "README.md" do
       digest = Digest::SHA256.hexdigest(content)
 
       # cat README.md | sha256sum
-      if digest != "afe979dee328947080f88e5917e6a13fc95584de7d32a946ecac23f6e9cad902"
+      if digest != "dd9d2ba2023393ec013248de66554ef939ef44757c1c446265780cfd51deadbc"
         raise "Invalid README file detected: #{digest}"
       end
 

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "README.md" do
       digest = Digest::SHA256.hexdigest(content)
 
       # cat README.md | sha256sum
-      if digest != "dd9d2ba2023393ec013248de66554ef939ef44757c1c446265780cfd51deadbc"
+      if digest != "452f80b7197e428ac096590915bcfceda7b67e5e63ed1426d2e3b4239a62246d"
         raise "Invalid README file detected: #{digest}"
       end
 


### PR DESCRIPTION
`Keisan::Calculator#evaluate` requires all variables/functions to be defined.  However, the user might still want to see the simplified version of an expression even with undefined elements present.  This PR adds the `Keisan::Calculator#simplify` method to accomplish this.

```ruby
calculator.evaluate("1*(0*2+x*g(t))")
#=> Keisan::Exceptions::UndefinedVariableError: x
calculator.simplify("1*(0*2+x*g(t))")
#=> "x*g(t)"
```

This can be used to just see what the result of a differentiation operator is too

```ruby
calculator.simplify("diff(sin(2*x), x)")
#=> "2*cos(2*x)"
```

This also adds another useful helper method: `ast` which simply parses an expression and returns the AST to the user.  This is for a user who might want to do their own manipulations to the syntax tree.