### PR TITLE
Remove unnecessary namespacing

### DIFF
--- a/lib/keisan/ast/boolean.rb
+++ b/lib/keisan/ast/boolean.rb
@@ -12,14 +12,14 @@ module Keisan
       end
 
       def !
-        AST::Boolean.new(!bool)
+        Boolean.new(!bool)
       end
 
       def and(other)
         other = other.to_node
         case other
-        when AST::Boolean
-          AST::Boolean.new(bool && other.bool)
+        when Boolean
+          Boolean.new(bool && other.bool)
         else
           super
         end
@@ -28,8 +28,8 @@ module Keisan
       def or(other)
         other = other.to_node
         case other
-        when AST::Boolean
-          AST::Boolean.new(bool || other.bool)
+        when Boolean
+          Boolean.new(bool || other.bool)
         else
           super
         end

--- a/lib/keisan/ast/builder.rb
+++ b/lib/keisan/ast/builder.rb
@@ -4,11 +4,11 @@ module Keisan
       # Build from parser
       def initialize(string: nil, parser: nil, components: nil)
         if [string, parser, components].select(&:nil?).size != 2
-          raise Keisan::Exceptions::InternalError.new("Require one of string, parser or components")
+          raise Exceptions::InternalError.new("Require one of string, parser or components")
         end
 
         if !string.nil?
-          @components = Keisan::Parser.new(string: string).components
+          @components = Parser.new(string: string).components
         elsif !parser.nil?
           @components = parser.components
         else
@@ -16,15 +16,15 @@ module Keisan
         end
 
         @lines = @components.split {|component|
-          component.is_a?(Keisan::Parsing::LineSeparator)
+          component.is_a?(Parsing::LineSeparator)
         }.reject(&:empty?)
 
-        @line_builders = @lines.map {|line| Keisan::AST::LineBuilder.new(line)}
+        @line_builders = @lines.map {|line| LineBuilder.new(line)}
 
         if @line_builders.size == 1
           @node = @line_builders.first.ast
         else
-          @node = Keisan::AST::MultiLine.new(@line_builders.map(&:ast))
+          @node = MultiLine.new(@line_builders.map(&:ast))
         end
       end
 

--- a/lib/keisan/ast/exponent.rb
+++ b/lib/keisan/ast/exponent.rb
@@ -19,20 +19,20 @@ module Keisan
           child ** total
         end
 
-        unless reduced.is_a?(AST::Exponent)
+        unless reduced.is_a?(Exponent)
           return reduced.simplify(context)
         end
 
         if reduced.children.count != 2
-          raise Keisan::Exceptions::InternalError.new("Exponent should be binary")
+          raise Exceptions::InternalError.new("Exponent should be binary")
         end
         @children = reduced.children
 
-        if children[1].is_a?(AST::Number) && children[1].value(context) == 1
+        if children[1].is_a?(Number) && children[1].value(context) == 1
           return children[0]
         end
 
-        if children.all? {|child| child.is_a?(AST::Number)}
+        if children.all? {|child| child.is_a?(Number)}
           (children[0] ** children[1]).simplify(context)
         else
           self
@@ -57,7 +57,7 @@ module Keisan
         exponent = children[1].simplified(context)
 
         # Special simple case where exponent is a pure number
-        if exponent.is_a?(AST::Number)
+        if exponent.is_a?(Number)
           return (exponent * base.differentiate(variable, context) * base ** (exponent -1)).simplify(context)
         end
 
@@ -65,7 +65,7 @@ module Keisan
         exponent_diff = exponent.differentiate(variable, context)
 
         res = base ** exponent * (
-          exponent_diff * AST::Function.new([base], "log") +
+          exponent_diff * Function.new([base], "log") +
           base_diff * exponent / base
         )
         res.simplify(context)

--- a/lib/keisan/ast/function.rb
+++ b/lib/keisan/ast/function.rb
@@ -9,12 +9,12 @@ module Keisan
       end
 
       def value(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         function_from_context(context).value(self, context)
       end
 
       def unbound_functions(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
 
         functions = children.inject(Set.new) do |res, child|
           res | child.unbound_functions(context)
@@ -24,7 +24,7 @@ module Keisan
       end
 
       def function_defined?(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         context.has_function?(name)
       end
 
@@ -34,7 +34,7 @@ module Keisan
 
       def ==(other)
         case other
-        when AST::Function
+        when Function
           name == other.name && super
         else
           false
@@ -42,7 +42,7 @@ module Keisan
       end
 
       def evaluate(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
 
         if function_defined?(context)
           function_from_context(context).evaluate(self, context)
@@ -71,12 +71,12 @@ module Keisan
         function = function_from_context(context)
         function.differentiate(self, variable, context)
 
-      rescue Keisan::Exceptions::UndefinedFunctionError, Keisan::Exceptions::NotImplementedError
+      rescue Exceptions::UndefinedFunctionError, Exceptions::NotImplementedError
         unless unbound_variables(context).include?(variable.name)
-          return AST::Number.new(0)
+          return Number.new(0)
         end
 
-        AST::Function.new([self, variable], "diff")
+        self.class.new([self, variable], "diff")
       end
     end
   end

--- a/lib/keisan/ast/indexing.rb
+++ b/lib/keisan/ast/indexing.rb
@@ -17,13 +17,13 @@ module Keisan
       end
 
       def evaluate(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         @children = children.map {|child| child.evaluate(context)}
         @indexes = indexes.map {|index| index.evaluate(context)}
 
         case child
-        when AST::List
-          if @indexes.size == 1 && @indexes.first.is_a?(AST::Number)
+        when List
+          if @indexes.size == 1 && @indexes.first.is_a?(Number)
             return child.children[@indexes.first.value(context)].evaluate(context)
           end
         end
@@ -38,8 +38,8 @@ module Keisan
         @children = [child.simplify(context)]
 
         case child
-        when AST::List
-          if @indexes.size == 1 && @indexes.first.is_a?(AST::Number)
+        when List
+          if @indexes.size == 1 && @indexes.first.is_a?(Number)
             return child.children[@indexes.first.value(context)].simplify(context)
           end
         end

--- a/lib/keisan/ast/list.rb
+++ b/lib/keisan/ast/list.rb
@@ -2,7 +2,7 @@ module Keisan
   module AST
     class List < Parent
       def value(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         children.map {|child| child.value(context)}
       end
 

--- a/lib/keisan/ast/logical_and.rb
+++ b/lib/keisan/ast/logical_and.rb
@@ -14,7 +14,7 @@ module Keisan
       end
 
       def value(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         children[0].value(context) && children[1].value(context)
       end
     end

--- a/lib/keisan/ast/logical_or.rb
+++ b/lib/keisan/ast/logical_or.rb
@@ -14,7 +14,7 @@ module Keisan
       end
 
       def value(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         children[0].value(context) || children[1].value(context)
       end
     end

--- a/lib/keisan/ast/node.rb
+++ b/lib/keisan/ast/node.rb
@@ -2,7 +2,7 @@ module Keisan
   module AST
     class Node
       def value(context = nil)
-        raise Keisan::Exceptions::NotImplementedError.new
+        raise Exceptions::NotImplementedError.new
       end
 
       def unbound_variables(context = nil)
@@ -34,7 +34,7 @@ module Keisan
       end
 
       def differentiate(variable, context = nil)
-        raise Keisan::Exceptions::NonDifferentiableError.new
+        raise Exceptions::NonDifferentiableError.new
       end
 
       def replace(variable, replacement)
@@ -50,41 +50,41 @@ module Keisan
       end
 
       def +(other)
-        AST::Plus.new(
+        Plus.new(
           [self, other.to_node]
         )
       end
 
       def -(other)
-        AST::Plus.new(
-          [self, AST::UnaryMinus.new(other.to_node)]
+        Plus.new(
+          [self, UnaryMinus.new(other.to_node)]
         )
       end
 
       def *(other)
-        AST::Times.new(
+        Times.new(
           [self, other.to_node]
         )
       end
 
       def /(other)
-        AST::Times.new(
-          [self, AST::UnaryInverse.new(other.to_node)]
+        Times.new(
+          [self, UnaryInverse.new(other.to_node)]
         )
       end
 
       def %(other)
-        AST::Modulo.new(
+        Modulo.new(
           [self, other.to_node]
         )
       end
 
       def !
-        AST::UnaryLogicalNot.new(self)
+        UnaryLogicalNot.new(self)
       end
 
       def ~
-        AST::UnaryBitwiseNot.new(self)
+        UnaryBitwiseNot.new(self)
       end
 
       def +@
@@ -92,55 +92,55 @@ module Keisan
       end
 
       def -@
-        AST::UnaryMinus.new(self)
+        UnaryMinus.new(self)
       end
 
       def **(other)
-        AST::Exponent.new([self, other.to_node])
+        Exponent.new([self, other.to_node])
       end
 
       def &(other)
-        AST::BitwiseAnd.new([self, other.to_node])
+        BitwiseAnd.new([self, other.to_node])
       end
 
       def ^(other)
-        AST::BitwiseXor.new([self, other.to_node])
+        BitwiseXor.new([self, other.to_node])
       end
 
       def |(other)
-        AST::BitwiseOr.new([self, other.to_node])
+        BitwiseOr.new([self, other.to_node])
       end
 
       def >(other)
-        AST::LogicalGreaterThan.new([self, other.to_node])
+        LogicalGreaterThan.new([self, other.to_node])
       end
 
       def >=(other)
-        AST::LogicalGreaterThanOrEqualTo.new([self, other.to_node])
+        LogicalGreaterThanOrEqualTo.new([self, other.to_node])
       end
 
       def <(other)
-        AST::LogicalLessThan.new([self, other.to_node])
+        LogicalLessThan.new([self, other.to_node])
       end
 
       def <=(other)
-        AST::LogicalLessThanOrEqualTo.new([self, other.to_node])
+        LogicalLessThanOrEqualTo.new([self, other.to_node])
       end
 
       def equal(other)
-        AST::LogicalEqual.new([self, other.to_node])
+        LogicalEqual.new([self, other.to_node])
       end
 
       def not_equal(other)
-        AST::LogicalNotEqual.new([self, other.to_node])
+        LogicalNotEqual.new([self, other.to_node])
       end
 
       def and(other)
-        AST::LogicalAnd.new([self, other.to_node])
+        LogicalAnd.new([self, other.to_node])
       end
 
       def or(other)
-        AST::LogicalOr.new([self, other.to_node])
+        LogicalOr.new([self, other.to_node])
       end
     end
   end

--- a/lib/keisan/ast/number.rb
+++ b/lib/keisan/ast/number.rb
@@ -12,18 +12,18 @@ module Keisan
       end
 
       def -@
-        AST::Number.new(-value)
+        Number.new(-value)
       end
 
       def +@
-        AST::Number.new(value)
+        Number.new(value)
       end
 
       def +(other)
         other = other.to_node
         case other
-        when AST::Number
-          AST::Number.new(value + other.value)
+        when Number
+          Number.new(value + other.value)
         else
           super
         end
@@ -36,8 +36,8 @@ module Keisan
       def *(other)
         other = other.to_node
         case other
-        when AST::Number
-          AST::Number.new(value * other.value)
+        when Number
+          Number.new(value * other.value)
         else
           super
         end
@@ -46,8 +46,8 @@ module Keisan
       def /(other)
         other = other.to_node
         case other
-        when AST::Number
-          AST::Number.new(Rational(value, other.value))
+        when Number
+          Number.new(Rational(value, other.value))
         else
           super
         end
@@ -56,8 +56,8 @@ module Keisan
       def **(other)
         other = other.to_node
         case other
-        when AST::Number
-          AST::Number.new(value ** other.value)
+        when Number
+          Number.new(value ** other.value)
         else
           super
         end
@@ -66,8 +66,8 @@ module Keisan
       def %(other)
         other = other.to_node
         case other
-        when AST::Number
-          AST::Number.new(value % other.value)
+        when Number
+          Number.new(value % other.value)
         else
           super
         end
@@ -76,22 +76,22 @@ module Keisan
       def &(other)
         other = other.to_node
         case other
-        when AST::Number
-          AST::Number.new(value & other.value)
+        when Number
+          Number.new(value & other.value)
         else
           super
         end
       end
 
       def ~
-        AST::Number.new(~value)
+        Number.new(~value)
       end
 
       def ^(other)
         other = other.to_node
         case other
-        when AST::Number
-          AST::Number.new(value ^ other.value)
+        when Number
+          Number.new(value ^ other.value)
         else
           super
         end
@@ -100,8 +100,8 @@ module Keisan
       def |(other)
         other = other.to_node
         case other
-        when AST::Number
-          AST::Number.new(value | other.value)
+        when Number
+          Number.new(value | other.value)
         else
           super
         end
@@ -110,8 +110,8 @@ module Keisan
       def >(other)
         other = other.to_node
         case other
-        when AST::Number
-          AST::Boolean.new(value > other.value)
+        when Number
+          Boolean.new(value > other.value)
         else
           super
         end
@@ -120,8 +120,8 @@ module Keisan
       def >=(other)
         other = other.to_node
         case other
-        when AST::Number
-          AST::Boolean.new(value >= other.value)
+        when Number
+          Boolean.new(value >= other.value)
         else
           super
         end
@@ -130,8 +130,8 @@ module Keisan
       def <(other)
         other = other.to_node
         case other
-        when AST::Number
-          AST::Boolean.new(value < other.value)
+        when Number
+          Boolean.new(value < other.value)
         else
           super
         end
@@ -140,8 +140,8 @@ module Keisan
       def <=(other)
         other = other.to_node
         case other
-        when AST::Number
-          AST::Boolean.new(value <= other.value)
+        when Number
+          Boolean.new(value <= other.value)
         else
           super
         end
@@ -150,8 +150,8 @@ module Keisan
       def equal(other)
         other = other.to_node
         case other
-        when AST::Number
-          AST::Boolean.new(value == other.value)
+        when Number
+          Boolean.new(value == other.value)
         else
           super
         end
@@ -160,8 +160,8 @@ module Keisan
       def not_equal(other)
         other = other.to_node
         case other
-        when AST::Number
-          AST::Boolean.new(value != other.value)
+        when Number
+          Boolean.new(value != other.value)
         else
           super
         end

--- a/lib/keisan/ast/operator.rb
+++ b/lib/keisan/ast/operator.rb
@@ -38,7 +38,7 @@ module Keisan
 
       def initialize(children = [], parsing_operators = [])
         unless parsing_operators.empty? || children.count == parsing_operators.count + 1
-          raise Keisan::Exceptions::ASTError.new("Mismatch of children and operators")
+          raise Exceptions::ASTError.new("Mismatch of children and operators")
         end
 
         children = Array.wrap(children)
@@ -80,11 +80,11 @@ module Keisan
       end
 
       def self.symbol
-        raise Keisan::Exceptions::NotImplementedError.new
+        raise Exceptions::NotImplementedError.new
       end
 
       def blank_value
-        raise Keisan::Exceptions::NotImplementedError.new
+        raise Exceptions::NotImplementedError.new
       end
 
       def value(context = nil)
@@ -103,7 +103,7 @@ module Keisan
       def to_s
         children.map do |child|
           case child
-          when AST::Operator
+          when Operator
             "(#{child.to_s})"
           else
             "#{child.to_s}"

--- a/lib/keisan/ast/parent.rb
+++ b/lib/keisan/ast/parent.rb
@@ -6,20 +6,20 @@ module Keisan
       def initialize(children = [])
         children = Array.wrap(children).map(&:to_node)
         unless children.is_a?(Array) && children.all? {|children| children.is_a?(Node)}
-          raise Keisan::Exceptions::InternalError.new
+          raise Exceptions::InternalError.new
         end
         @children = children
       end
 
       def unbound_variables(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         children.inject(Set.new) do |vars, child|
           vars | child.unbound_variables(context)
         end
       end
 
       def unbound_functions(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         children.inject(Set.new) do |fns, child|
           fns | child.unbound_functions(context)
         end
@@ -45,7 +45,7 @@ module Keisan
       end
 
       def evaluate(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         @children = children.map {|child| child.evaluate(context)}
         self
       end

--- a/lib/keisan/ast/plus.rb
+++ b/lib/keisan/ast/plus.rb
@@ -39,25 +39,25 @@ module Keisan
         # Commutative, so pull in operands of any `Plus` operators
         @children = children.inject([]) do |new_children, cur_child|
           case cur_child
-          when AST::Plus
+          when Plus
             new_children + cur_child.children
           else
             new_children << cur_child
           end
         end
 
-        if children.all? {|child| child.is_a?(Keisan::AST::String)}
-          return Keisan::AST::String.new(children.inject("") do |result, child|
+        if children.all? {|child| child.is_a?(String)}
+          return String.new(children.inject("") do |result, child|
             result + child.value
           end)
-        elsif children.all? {|child| child.is_a?(Keisan::AST::List)}
-          return Keisan::AST::List.new(children.inject([]) do |result, child|
+        elsif children.all? {|child| child.is_a?(List)}
+          return List.new(children.inject([]) do |result, child|
             result + child.value
           end)
         end
 
-        constants, non_constants = *children.partition {|child| child.is_a?(AST::Number)}
-        constant = constants.inject(AST::Number.new(0), &:+).simplify(context)
+        constants, non_constants = *children.partition {|child| child.is_a?(Number)}
+        constant = constants.inject(Number.new(0), &:+).simplify(context)
 
         if non_constants.empty?
           constant
@@ -72,15 +72,15 @@ module Keisan
       end
 
       def differentiate(variable, context = nil)
-        AST::Plus.new(children.map {|child| child.differentiate(variable, context)}).simplify(context)
+        Plus.new(children.map {|child| child.differentiate(variable, context)}).simplify(context)
       end
 
       private
 
       def convert_minus_to_plus!
         @parsing_operators.each.with_index do |parsing_operator, index|
-          if parsing_operator.is_a?(Keisan::Parsing::Minus)
-            @children[index+1] = Keisan::AST::UnaryMinus.new(@children[index+1])
+          if parsing_operator.is_a?(Parsing::Minus)
+            @children[index+1] = UnaryMinus.new(@children[index+1])
           end
         end
       end

--- a/lib/keisan/ast/string.rb
+++ b/lib/keisan/ast/string.rb
@@ -13,10 +13,10 @@ module Keisan
 
       def +(other)
         case other
-        when AST::String
-          AST::String.new(value + other.value)
+        when String
+          String.new(value + other.value)
         else
-          raise Keisan::Exceptions::TypeError.new("#{other}'s type is invalid, #{other.class}")
+          raise Exceptions::TypeError.new("#{other}'s type is invalid, #{other.class}")
         end
       end
 

--- a/lib/keisan/ast/times.rb
+++ b/lib/keisan/ast/times.rb
@@ -26,17 +26,17 @@ module Keisan
         # Commutative, so pull in operands of any `Times` operators
         @children = children.inject([]) do |new_children, cur_child|
           case cur_child
-          when AST::Times
+          when Times
             new_children + cur_child.children
           else
             new_children << cur_child
           end
         end
 
-        constants, non_constants = *children.partition {|child| child.is_a?(AST::Number)}
-        constant = constants.inject(AST::Number.new(1), &:*).simplify(context)
+        constants, non_constants = *children.partition {|child| child.is_a?(Number)}
+        constant = constants.inject(Number.new(1), &:*).simplify(context)
 
-        return Keisan::AST::Number.new(0) if constant.value(context) == 0
+        return Number.new(0) if constant.value(context) == 0
 
         if non_constants.empty?
           constant
@@ -52,9 +52,9 @@ module Keisan
 
       def differentiate(variable, context = nil)
         # Product rule
-        AST::Plus.new(
+        Plus.new(
           children.map.with_index do |child,i|
-            AST::Times.new(
+            Times.new(
               children.slice(0,i) + [child.differentiate(variable, context)] + children.slice(i+1,children.size)
             )
           end
@@ -65,8 +65,8 @@ module Keisan
 
       def convert_divide_to_inverse!
         @parsing_operators.each.with_index do |parsing_operator, index|
-          if parsing_operator.is_a?(Keisan::Parsing::Divide)
-            @children[index+1] = Keisan::AST::UnaryInverse.new(@children[index+1])
+          if parsing_operator.is_a?(Parsing::Divide)
+            @children[index+1] = UnaryInverse.new(@children[index+1])
           end
         end
       end

--- a/lib/keisan/ast/unary_inverse.rb
+++ b/lib/keisan/ast/unary_inverse.rb
@@ -18,8 +18,8 @@ module Keisan
 
         @children = [child.simplify(context)]
         case child
-        when AST::Number
-          AST::Number.new(Rational(1,child.value(context))).simplify(context)
+        when Number
+          Number.new(Rational(1,child.value(context))).simplify(context)
         else
           (child ** -1).simplify(context)
         end
@@ -27,12 +27,12 @@ module Keisan
 
       def differentiate(variable, context = nil)
         context ||= Context.new
-        AST::Times.new(
+        Times.new(
           [
-            AST::UnaryMinus.new(child.differentiate(variable, context)),
-            AST::UnaryInverse.new(
-              AST::Exponent.new([
-                child.deep_dup, AST::Number.new(2)
+            UnaryMinus.new(child.differentiate(variable, context)),
+            UnaryInverse.new(
+              Exponent.new([
+                child.deep_dup, Number.new(2)
               ])
             )
           ]

--- a/lib/keisan/ast/unary_minus.rb
+++ b/lib/keisan/ast/unary_minus.rb
@@ -17,11 +17,11 @@ module Keisan
         context ||= Context.new
 
         case child
-        when AST::Number
-          AST::Number.new(-child.value(context)).simplify(context)
+        when Number
+          Number.new(-child.value(context)).simplify(context)
         else
-          AST::Times.new([
-            AST::Number.new(-1),
+          Times.new([
+            Number.new(-1),
             child
           ]).simplify(context)
         end
@@ -29,7 +29,7 @@ module Keisan
 
       def differentiate(variable, context = nil)
         context ||= Context.new
-        AST::Times.new([
+        Times.new([
           -1.to_node,
           child.differentiate(variable, context)
         ]).simplify(context)

--- a/lib/keisan/ast/unary_operator.rb
+++ b/lib/keisan/ast/unary_operator.rb
@@ -5,7 +5,7 @@ module Keisan
         children = Array.wrap(children)
         super(children)
         if children.count != 1
-          raise Keisan::Exceptions::ASTError.new("Unary operator takes has a single child")
+          raise Exceptions::ASTError.new("Unary operator takes has a single child")
         end
       end
 
@@ -26,7 +26,7 @@ module Keisan
       end
 
       def to_s
-        if child.is_a?(AST::Operator)
+        if child.is_a?(Operator)
           "#{symbol.to_s}(#{child.to_s})"
         else
           "#{symbol.to_s}#{child.to_s}"

--- a/lib/keisan/ast/unary_plus.rb
+++ b/lib/keisan/ast/unary_plus.rb
@@ -11,8 +11,8 @@ module Keisan
 
       def simplify(context = nil)
         case child
-        when AST::Number
-          AST::Number.new(child.value(context)).simplify(context)
+        when Number
+          Number.new(child.value(context)).simplify(context)
         else
           super
         end

--- a/lib/keisan/ast/variable.rb
+++ b/lib/keisan/ast/variable.rb
@@ -8,12 +8,12 @@ module Keisan
       end
 
       def value(context = nil)
-        context = Keisan::Context.new if context.nil?
+        context = Context.new if context.nil?
         context.variable(name).value(context)
       end
 
       def unbound_variables(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         context.has_variable?(name) ? Set.new : Set.new([name])
       end
 
@@ -26,12 +26,12 @@ module Keisan
       end
 
       def evaluate(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         if context.has_variable?(name)
           variable = context.variable(name)
           # The variable might just be a variable, i.e. probably in function definition
-          if variable.is_a?(AST::Node)
-            variable.is_a?(AST::Variable) ? variable : variable.evaluate(context)
+          if variable.is_a?(Node)
+            variable.is_a?(Variable) ? variable : variable.evaluate(context)
           else
             variable
           end
@@ -41,7 +41,7 @@ module Keisan
       end
 
       def simplify(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         if context.has_variable?(name)
           context.variable(name).to_node.simplify(context)
         else
@@ -58,7 +58,7 @@ module Keisan
       end
 
       def differentiate(variable, context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
 
         if name == variable.name && !context.has_variable?(name)
           1.to_node

--- a/lib/keisan/context.rb
+++ b/lib/keisan/context.rb
@@ -26,7 +26,7 @@ module Keisan
         case value
         when Proc
           child.register_function!(name, value)
-        when Keisan::Functions::ProcFunction
+        when Functions::ProcFunction
           child.register_function!(name, value.function_proc)
         else
           child.register_variable!(name, value)

--- a/lib/keisan/evaluator.rb
+++ b/lib/keisan/evaluator.rb
@@ -8,12 +8,12 @@ module Keisan
 
     def evaluate(expression, definitions = {})
       context = calculator.context.spawn_child(definitions: definitions, transient: true)
-      ast = Keisan::AST.parse(expression)
+      ast = AST.parse(expression)
       evaluation = ast.evaluate(context)
 
       case ast
-      when Keisan::AST::Assignment
-        if ast.children.first.is_a?(Keisan::AST::Variable)
+      when AST::Assignment
+        if ast.children.first.is_a?(AST::Variable)
           context.variable(ast.children.first.name).value(context)
         end
       else
@@ -23,12 +23,12 @@ module Keisan
 
     def simplify(expression, definitions = {})
       context = calculator.context.spawn_child(definitions: definitions, transient: true)
-      ast = Keisan::AST.parse(expression)
+      ast = AST.parse(expression)
       ast.simplify(context)
     end
 
     def ast(expression)
-      Keisan::AST.parse(expression)
+      AST.parse(expression)
     end
   end
 end

--- a/lib/keisan/function.rb
+++ b/lib/keisan/function.rb
@@ -7,19 +7,19 @@ module Keisan
     end
 
     def value(ast_function, context = nil)
-      raise Keisan::Exceptions::NotImplementedError.new
+      raise Exceptions::NotImplementedError.new
     end
 
     def evaluate(ast_function, context = nil)
-      raise Keisan::Exceptions::NotImplementedError.new
+      raise Exceptions::NotImplementedError.new
     end
 
     def simplify(ast_function, context = nil)
-      raise Keisan::Exceptions::NotImplementedError.new
+      raise Exceptions::NotImplementedError.new
     end
 
     def differentiate(ast_function, variable, context = nil)
-      raise Keisan::Exceptions::NotImplementedError.new
+      raise Exceptions::NotImplementedError.new
     end
   end
 end

--- a/lib/keisan/functions/cbrt.rb
+++ b/lib/keisan/functions/cbrt.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        Keisan::AST::Exponent.new([argument, Rational(-2,3)]) / 3
+        AST::Exponent.new([argument, Rational(-2,3)]) / 3
       end
     end
   end

--- a/lib/keisan/functions/cos.rb
+++ b/lib/keisan/functions/cos.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        -Keisan::AST::Function.new([argument], "sin")
+        -AST::Function.new([argument], "sin")
       end
     end
   end

--- a/lib/keisan/functions/cosh.rb
+++ b/lib/keisan/functions/cosh.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        Keisan::AST::Function.new([argument], "sinh")
+        AST::Function.new([argument], "sinh")
       end
     end
   end

--- a/lib/keisan/functions/cot.rb
+++ b/lib/keisan/functions/cot.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        -Keisan::AST::Exponent.new([Keisan::AST::Function.new([argument], "sin"), -2])
+        -AST::Exponent.new([AST::Function.new([argument], "sin"), -2])
       end
     end
   end

--- a/lib/keisan/functions/coth.rb
+++ b/lib/keisan/functions/coth.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        -Keisan::AST::Exponent.new([Keisan::AST::Function.new([argument], "sinh"), -2])
+        -AST::Exponent.new([AST::Function.new([argument], "sinh"), -2])
       end
     end
   end

--- a/lib/keisan/functions/csc.rb
+++ b/lib/keisan/functions/csc.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        -Keisan::AST::Function.new([argument], "cos") * Keisan::AST::Exponent.new([Keisan::AST::Function.new([argument], "sin"), -2])
+        -AST::Function.new([argument], "cos") * AST::Exponent.new([AST::Function.new([argument], "sin"), -2])
       end
     end
   end

--- a/lib/keisan/functions/csch.rb
+++ b/lib/keisan/functions/csch.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        -Keisan::AST::Function.new([argument], "cosh") * Keisan::AST::Exponent.new([Keisan::AST::Function.new([argument], "sinh"), -2])
+        -AST::Function.new([argument], "cosh") * AST::Exponent.new([AST::Function.new([argument], "sinh"), -2])
       end
     end
   end

--- a/lib/keisan/functions/default_registry.rb
+++ b/lib/keisan/functions/default_registry.rb
@@ -40,43 +40,43 @@ module Keisan
       private
 
       def self.register_defaults!(registry)
-        registry.register!(:if, Keisan::Functions::If.new, force: true)
-        registry.register!(:diff, Keisan::Functions::Diff.new, force: true)
-        registry.register!(:replace, Keisan::Functions::Replace.new, force: true)
-        registry.register!(:map, Keisan::Functions::Map.new, force: true)
-        registry.register!(:collect, Keisan::Functions::Map.new, force: true)
-        registry.register!(:filter, Keisan::Functions::Filter.new, force: true)
-        registry.register!(:select, Keisan::Functions::Filter.new, force: true)
-        registry.register!(:reduce, Keisan::Functions::Reduce.new, force: true)
-        registry.register!(:inject, Keisan::Functions::Reduce.new, force: true)
+        registry.register!(:if, If.new, force: true)
+        registry.register!(:diff, Diff.new, force: true)
+        registry.register!(:replace, Replace.new, force: true)
+        registry.register!(:map, Map.new, force: true)
+        registry.register!(:collect, Map.new, force: true)
+        registry.register!(:filter, Filter.new, force: true)
+        registry.register!(:select, Filter.new, force: true)
+        registry.register!(:reduce, Reduce.new, force: true)
+        registry.register!(:inject, Reduce.new, force: true)
 
         register_builtin_math!(registry)
         register_array_methods!(registry)
         register_random_methods!(registry)
 
-        registry.register!(:exp, Keisan::Functions::Exp.new, force: true)
-        registry.register!(:log, Keisan::Functions::Log.new, force: true)
+        registry.register!(:exp, Exp.new, force: true)
+        registry.register!(:log, Log.new, force: true)
 
-        registry.register!(:sin, Keisan::Functions::Sin.new, force: true)
-        registry.register!(:cos, Keisan::Functions::Cos.new, force: true)
-        registry.register!(:tan, Keisan::Functions::Tan.new, force: true)
-        registry.register!(:cot, Keisan::Functions::Cot.new, force: true)
-        registry.register!(:sec, Keisan::Functions::Sec.new, force: true)
-        registry.register!(:csc, Keisan::Functions::Csc.new, force: true)
+        registry.register!(:sin, Sin.new, force: true)
+        registry.register!(:cos, Cos.new, force: true)
+        registry.register!(:tan, Tan.new, force: true)
+        registry.register!(:cot, Cot.new, force: true)
+        registry.register!(:sec, Sec.new, force: true)
+        registry.register!(:csc, Csc.new, force: true)
 
-        registry.register!(:sinh, Keisan::Functions::Sinh.new, force: true)
-        registry.register!(:cosh, Keisan::Functions::Cosh.new, force: true)
-        registry.register!(:tanh, Keisan::Functions::Tanh.new, force: true)
-        registry.register!(:coth, Keisan::Functions::Coth.new, force: true)
-        registry.register!(:sech, Keisan::Functions::Sech.new, force: true)
-        registry.register!(:csch, Keisan::Functions::Csch.new, force: true)
+        registry.register!(:sinh, Sinh.new, force: true)
+        registry.register!(:cosh, Cosh.new, force: true)
+        registry.register!(:tanh, Tanh.new, force: true)
+        registry.register!(:coth, Coth.new, force: true)
+        registry.register!(:sech, Sech.new, force: true)
+        registry.register!(:csch, Csch.new, force: true)
 
-        registry.register!(:sqrt, Keisan::Functions::Sqrt.new, force: true)
-        registry.register!(:cbrt, Keisan::Functions::Cbrt.new, force: true)
+        registry.register!(:sqrt, Sqrt.new, force: true)
+        registry.register!(:cbrt, Cbrt.new, force: true)
 
-        registry.register!(:abs, Keisan::Functions::Abs.new, force: true)
-        registry.register!(:real, Keisan::Functions::Real.new, force: true)
-        registry.register!(:imag, Keisan::Functions::Imag.new, force: true)
+        registry.register!(:abs, Abs.new, force: true)
+        registry.register!(:real, Real.new, force: true)
+        registry.register!(:imag, Imag.new, force: true)
       end
 
       def self.register_builtin_math!(registry)
@@ -113,7 +113,7 @@ module Keisan
             shift = args[2]
 
             if shift == 0 or !shift.is_a?(Integer)
-              raise Keisan::Exceptions::InvalidFunctionError.new("range's 3rd argument must be non-zero integer")
+              raise Exceptions::InvalidFunctionError.new("range's 3rd argument must be non-zero integer")
             end
 
             result = []
@@ -132,14 +132,14 @@ module Keisan
 
             result
           else
-            raise Keisan::Exceptions::InvalidFunctionError.new("range takes 1 to 3 arguments")
+            raise Exceptions::InvalidFunctionError.new("range takes 1 to 3 arguments")
           end
         }, force: true)
       end
 
       def self.register_random_methods!(registry)
-        registry.register!(:rand, Keisan::Functions::Rand.new, force: true)
-        registry.register!(:sample, Keisan::Functions::Sample.new, force: true)
+        registry.register!(:rand, Rand.new, force: true)
+        registry.register!(:sample, Sample.new, force: true)
       end
     end
   end

--- a/lib/keisan/functions/exp.rb
+++ b/lib/keisan/functions/exp.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        Keisan::AST::Function.new([argument], "exp")
+        AST::Function.new([argument], "exp")
       end
     end
   end

--- a/lib/keisan/functions/expression_function.rb
+++ b/lib/keisan/functions/expression_function.rb
@@ -1,6 +1,6 @@
 module Keisan
   module Functions
-    class ExpressionFunction < Keisan::Function
+    class ExpressionFunction < Function
       attr_reader :arguments, :expression
 
       def initialize(name, arguments, expression, transient_definitions)
@@ -24,7 +24,7 @@ module Keisan
       def value(ast_function, context = nil)
         verify_argument_size!(ast_function.children.count)
 
-        context ||= Keisan::Context.new
+        context ||= Context.new
         argument_values = ast_function.children.map {|child| child.value(context)}
         call(context, *argument_values)
       end
@@ -32,7 +32,7 @@ module Keisan
       def evaluate(ast_function, context = nil)
         verify_argument_size!(ast_function.children.count)
 
-        context ||= Keisan::Context.new
+        context ||= Context.new
         local = local_context_for(context)
 
         argument_values = ast_function.children.map {|child| child.evaluate(context)}
@@ -52,7 +52,7 @@ module Keisan
           ast_function.children.map {|child| child.evaluate(context)}
         )
 
-        if ast_function.children.all? {|child| child.is_a?(Keisan::AST::ConstantLiteral)}
+        if ast_function.children.all? {|child| child.is_a?(AST::ConstantLiteral)}
           value(ast_function, context).to_node.simplify(context)
         else
           ast_function
@@ -78,10 +78,10 @@ module Keisan
           child.differentiate(variable, context)
         end
 
-        Keisan::AST::Plus.new(
+        AST::Plus.new(
           argument_derivatives.map.with_index {|argument_derivative, i|
             partial_derivative = partial_derivatives[i].replace(argument_variables[i], argument_values[i])
-            Keisan::AST::Times.new([argument_derivative, partial_derivative])
+            AST::Times.new([argument_derivative, partial_derivative])
           }
         )
       end
@@ -89,7 +89,7 @@ module Keisan
       private
 
       def argument_variables
-        @argument_variables ||= arguments.map {|argument| Keisan::AST::Variable.new(argument)}
+        @argument_variables ||= arguments.map {|argument| AST::Variable.new(argument)}
       end
 
       def partial_derivatives
@@ -100,12 +100,12 @@ module Keisan
 
       def verify_argument_size!(argument_size)
         unless @arguments.count == argument_size
-          raise Keisan::Exceptions::InvalidFunctionError.new("Invalid number of arguments for #{name} function")
+          raise Exceptions::InvalidFunctionError.new("Invalid number of arguments for #{name} function")
         end
       end
 
       def local_context_for(context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         context.spawn_child(definitions: @transient_definitions, shadowed: @arguments, transient: true)
       end
     end

--- a/lib/keisan/functions/filter.rb
+++ b/lib/keisan/functions/filter.rb
@@ -1,6 +1,6 @@
 module Keisan
   module Functions
-    class Filter < Keisan::Function
+    class Filter < Function
       # Filters (list, variable, expression)
       # e.g. filter([1,2,3,4], x, x % 2 == 0)
       # should give [2,4]
@@ -20,19 +20,19 @@ module Keisan
       def simplify(ast_function, context = nil)
         list, variable, expression = list_variable_expression_for(ast_function, context)
 
-        context ||= Keisan::Context.new
+        context ||= Context.new
         local = context.spawn_child(transient: false, shadowed: [variable.name])
 
-        Keisan::AST::List.new(
+        AST::List.new(
           list.children.select do |element|
             local.register_variable!(variable, element)
             result = expression.evaluate(local)
 
             case result
-            when Keisan::AST::Boolean
+            when AST::Boolean
               result.value
             else
-              raise Keisan::Exceptions::InvalidFunctionError.new("Filter requires expression to be a logical expression")
+              raise Exceptions::InvalidFunctionError.new("Filter requires expression to be a logical expression")
             end
           end
         )
@@ -42,19 +42,19 @@ module Keisan
 
       def list_variable_expression_for(ast_function, context)
         unless ast_function.children.size == 3
-          raise Keisan::Exceptions::InvalidFunctionError.new("Require 3 arguments to filter")
+          raise Exceptions::InvalidFunctionError.new("Require 3 arguments to filter")
         end
 
         list = ast_function.children[0].simplify(context)
         variable = ast_function.children[1]
         expression = ast_function.children[2]
 
-        unless list.is_a?(Keisan::AST::List)
-          raise Keisan::Exceptions::InvalidFunctionError.new("First argument to filter must be a list")
+        unless list.is_a?(AST::List)
+          raise Exceptions::InvalidFunctionError.new("First argument to filter must be a list")
         end
 
-        unless variable.is_a?(Keisan::AST::Variable)
-          raise Keisan::Exceptions::InvalidFunctionError.new("Second argument to filter must be a variable")
+        unless variable.is_a?(AST::Variable)
+          raise Exceptions::InvalidFunctionError.new("Second argument to filter must be a variable")
         end
 
         [list, variable, expression]

--- a/lib/keisan/functions/if.rb
+++ b/lib/keisan/functions/if.rb
@@ -1,15 +1,15 @@
 module Keisan
   module Functions
-    class If < Keisan::Function
+    class If < Function
       def initialize
         @name = "if"
       end
 
       def value(ast_function, context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
 
         unless (2..3).cover? ast_function.children.size
-          raise Keisan::Exceptions::InvalidFunctionError.new("Require 2 or 3 arguments to if")
+          raise Exceptions::InvalidFunctionError.new("Require 2 or 3 arguments to if")
         end
 
         bool = ast_function.children[0].value(context)
@@ -22,11 +22,11 @@ module Keisan
       end
 
       def evaluate(ast_function, context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
 
         bool = ast_function.children[0].evaluate(context)
 
-        if bool.is_a?(Keisan::AST::Boolean)
+        if bool.is_a?(AST::Boolean)
           node = bool.value ? ast_function.children[1] : ast_function.children[2]
           node.to_node.evaluate(context)
         else
@@ -38,7 +38,7 @@ module Keisan
         context ||= Context.new
         bool = ast_function.children[0].simplify(context)
 
-        if bool.is_a?(Keisan::AST::Boolean)
+        if bool.is_a?(AST::Boolean)
           if bool.value
             ast_function.children[1].to_node.simplify(context)
           else
@@ -51,7 +51,7 @@ module Keisan
 
       def differentiate(ast_function, variable, context = nil)
         context ||= Context.new
-        Keisan::AST::Function.new(
+        AST::Function.new(
           [
             ast_function.children[0],
             ast_function.children[1].differentiate(variable, context),

--- a/lib/keisan/functions/map.rb
+++ b/lib/keisan/functions/map.rb
@@ -1,6 +1,6 @@
 module Keisan
   module Functions
-    class Map < Keisan::Function
+    class Map < Function
       # Maps (list, variable, expression)
       # e.g. map([1,2,3], x, 2*x)
       # should give [2,4,6]
@@ -18,12 +18,12 @@ module Keisan
       end
 
       def simplify(ast_function, context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         list, variable, expression = list_variable_expression_for(ast_function, context)
 
         local = context.spawn_child(transient: false, shadowed: [variable.name])
 
-        Keisan::AST::List.new(
+        AST::List.new(
           list.children.map do |element|
             local.register_variable!(variable, element)
             expression.simplified(local)
@@ -35,19 +35,19 @@ module Keisan
 
       def list_variable_expression_for(ast_function, context)
         unless ast_function.children.size == 3
-          raise Keisan::Exceptions::InvalidFunctionError.new("Require 3 arguments to map")
+          raise Exceptions::InvalidFunctionError.new("Require 3 arguments to map")
         end
 
         list = ast_function.children[0].simplify(context)
         variable = ast_function.children[1]
         expression = ast_function.children[2]
 
-        unless list.is_a?(Keisan::AST::List)
-          raise Keisan::Exceptions::InvalidFunctionError.new("First argument to map must be a list")
+        unless list.is_a?(AST::List)
+          raise Exceptions::InvalidFunctionError.new("First argument to map must be a list")
         end
 
-        unless variable.is_a?(Keisan::AST::Variable)
-          raise Keisan::Exceptions::InvalidFunctionError.new("Second argument to map must be a variable")
+        unless variable.is_a?(AST::Variable)
+          raise Exceptions::InvalidFunctionError.new("Second argument to map must be a variable")
         end
 
         [list, variable, expression]

--- a/lib/keisan/functions/math_function.rb
+++ b/lib/keisan/functions/math_function.rb
@@ -11,7 +11,7 @@ module Keisan
       end
 
       def differentiate(ast_function, variable, context = nil)
-        raise Keisan::Exceptions::InvalidFunctionError.new unless ast_function.children.count == 1
+        raise Exceptions::InvalidFunctionError.new unless ast_function.children.count == 1
         context ||= Context.new
 
         argument_simplified = ast_function.children.first.simplify(context)
@@ -23,7 +23,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        raise Keisan::Exceptions::NotImplementedError.new
+        raise Exceptions::NotImplementedError.new
       end
 
       def self.apply_simplifications(simplified)

--- a/lib/keisan/functions/proc_function.rb
+++ b/lib/keisan/functions/proc_function.rb
@@ -1,10 +1,10 @@
 module Keisan
   module Functions
-    class ProcFunction < Keisan::Function
+    class ProcFunction < Function
       attr_reader :function_proc
 
       def initialize(name, function_proc)
-        raise Keisan::Exceptions::InvalidFunctionError.new unless function_proc.is_a?(Proc)
+        raise Exceptions::InvalidFunctionError.new unless function_proc.is_a?(Proc)
 
         super(name)
         @function_proc = function_proc
@@ -15,13 +15,13 @@ module Keisan
       end
 
       def value(ast_function, context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         argument_values = ast_function.children.map {|child| child.value(context)}
         call(context, *argument_values).value(context)
       end
 
       def evaluate(ast_function, context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
 
         ast_function.instance_variable_set(
           :@children,
@@ -43,7 +43,7 @@ module Keisan
           ast_function.children.map {|child| child.evaluate(context)}
         )
 
-        if ast_function.children.all? {|child| child.is_a?(Keisan::AST::ConstantLiteral)}
+        if ast_function.children.all? {|child| child.is_a?(AST::ConstantLiteral)}
           value(ast_function, context).to_node.simplify(context)
         else
           ast_function

--- a/lib/keisan/functions/rand.rb
+++ b/lib/keisan/functions/rand.rb
@@ -14,7 +14,7 @@ module Keisan
         when 2
           context.random.rand(args.first...args.last)
         else
-          raise Keisan::Exceptions::InvalidFunctionError.new
+          raise Exceptions::InvalidFunctionError.new
         end
       end
     end

--- a/lib/keisan/functions/reduce.rb
+++ b/lib/keisan/functions/reduce.rb
@@ -1,6 +1,6 @@
 module Keisan
   module Functions
-    class Reduce < Keisan::Function
+    class Reduce < Function
       # Reduces (list, initial, accumulator, variable, expression)
       # e.g. reduce([1,2,3,4], 0, total, x, total+x)
       # should give 10
@@ -18,7 +18,7 @@ module Keisan
       end
 
       def simplify(ast_function, context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         list, initial, accumulator, variable, expression = list_initial_accumulator_variable_expression_for(ast_function, context)
 
         local = context.spawn_child(transient: false, shadowed: [accumulator.name, variable.name])
@@ -37,7 +37,7 @@ module Keisan
 
       def list_initial_accumulator_variable_expression_for(ast_function, context)
         unless ast_function.children.size == 5
-          raise Keisan::Exceptions::InvalidFunctionError.new("Require 5 arguments to reduce")
+          raise Exceptions::InvalidFunctionError.new("Require 5 arguments to reduce")
         end
 
         list = ast_function.children[0].simplify(context)
@@ -46,16 +46,16 @@ module Keisan
         variable = ast_function.children[3]
         expression = ast_function.children[4]
 
-        unless list.is_a?(Keisan::AST::List)
-          raise Keisan::Exceptions::InvalidFunctionError.new("First argument to reduce must be a list")
+        unless list.is_a?(AST::List)
+          raise Exceptions::InvalidFunctionError.new("First argument to reduce must be a list")
         end
 
-        unless accumulator.is_a?(Keisan::AST::Variable)
-          raise Keisan::Exceptions::InvalidFunctionError.new("Third argument to reduce is accumulator and must be a variable")
+        unless accumulator.is_a?(AST::Variable)
+          raise Exceptions::InvalidFunctionError.new("Third argument to reduce is accumulator and must be a variable")
         end
 
-        unless variable.is_a?(Keisan::AST::Variable)
-          raise Keisan::Exceptions::InvalidFunctionError.new("Fourth argument to reduce is variable and must be a variable")
+        unless variable.is_a?(AST::Variable)
+          raise Exceptions::InvalidFunctionError.new("Fourth argument to reduce is variable and must be a variable")
         end
 
         [list, initial, accumulator, variable, expression]

--- a/lib/keisan/functions/registry.rb
+++ b/lib/keisan/functions/registry.rb
@@ -19,7 +19,7 @@ module Keisan
         end
 
         return default_registry[name] if @use_defaults && default_registry.has_name?(name)
-        raise Keisan::Exceptions::UndefinedFunctionError.new name
+        raise Exceptions::UndefinedFunctionError.new name
       end
 
       def locals
@@ -28,25 +28,25 @@ module Keisan
 
       def has?(name)
         !!self[name]
-      rescue Keisan::Exceptions::UndefinedFunctionError
+      rescue Exceptions::UndefinedFunctionError
         false
       end
 
       def register!(name, function, force: false)
-        raise Keisan::Exceptions::UnmodifiableError.new("Cannot modify frozen functions registry") if frozen?
+        raise Exceptions::UnmodifiableError.new("Cannot modify frozen functions registry") if frozen?
         name = name.to_s
 
         if !force && @use_defaults && default_registry.has_name?(name)
-          raise Keisan::Exceptions::UnmodifiableError.new("Cannot overwrite default function")
+          raise Exceptions::UnmodifiableError.new("Cannot overwrite default function")
         end
 
         case function
         when Proc
-          self[name] = Keisan::Functions::ProcFunction.new(name, function)
-        when Keisan::Function
+          self[name] = ProcFunction.new(name, function)
+        when Function
           self[name] = function
         else
-          raise Keisan::Exceptions::InvalidFunctionError.new
+          raise Exceptions::InvalidFunctionError.new
         end
       end
 

--- a/lib/keisan/functions/replace.rb
+++ b/lib/keisan/functions/replace.rb
@@ -1,17 +1,17 @@
 module Keisan
   module Functions
-    class Replace < Keisan::Function
+    class Replace < Function
       def initialize
         @name = "replace"
       end
 
       def value(ast_function, context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         evaluate(ast_function, context).value(context)
       end
 
       def evaluate(ast_function, context = nil)
-        context ||= Keisan::Context.new
+        context ||= Context.new
         expression, variable, replacement = expression_variable_replacement(ast_function)
 
         expression = expression.evaluate(context)
@@ -28,18 +28,18 @@ module Keisan
       private
 
       def expression_variable_replacement(ast_function)
-        unless ast_function.is_a?(Keisan::AST::Function) && ast_function.name == name
-          raise Keisan::Exceptions::InvalidFunctionError.new("Must receive replace function")
+        unless ast_function.is_a?(AST::Function) && ast_function.name == name
+          raise Exceptions::InvalidFunctionError.new("Must receive replace function")
         end
 
         unless ast_function.children.size == 3
-          raise Keisan::Exceptions::InvalidFunctionError.new("Require 3 arguments to replace")
+          raise Exceptions::InvalidFunctionError.new("Require 3 arguments to replace")
         end
 
         expression, variable, replacement = *ast_function.children.map(&:deep_dup)
 
-        unless variable.is_a?(Keisan::AST::Variable)
-          raise Keisan::Exceptions::InvalidFunctionError.new("Replace must replace a variable")
+        unless variable.is_a?(AST::Variable)
+          raise Exceptions::InvalidFunctionError.new("Replace must replace a variable")
         end
 
         [expression, variable, replacement]

--- a/lib/keisan/functions/sample.rb
+++ b/lib/keisan/functions/sample.rb
@@ -12,7 +12,7 @@ module Keisan
         when 1
           args.first.sample(random: context.random)
         else
-          raise Keisan::Exceptions::InvalidFunctionError.new
+          raise Exceptions::InvalidFunctionError.new
         end
       end
     end

--- a/lib/keisan/functions/sec.rb
+++ b/lib/keisan/functions/sec.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        Keisan::AST::Function.new([argument], "sin") * Keisan::AST::Exponent.new([Keisan::AST::Function.new([argument], "cos"), -2])
+        AST::Function.new([argument], "sin") * AST::Exponent.new([AST::Function.new([argument], "cos"), -2])
       end
     end
   end

--- a/lib/keisan/functions/sech.rb
+++ b/lib/keisan/functions/sech.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        -Keisan::AST::Function.new([argument], "sinh") * Keisan::AST::Exponent.new([Keisan::AST::Function.new([argument], "cosh"), -2])
+        -AST::Function.new([argument], "sinh") * AST::Exponent.new([AST::Function.new([argument], "cosh"), -2])
       end
     end
   end

--- a/lib/keisan/functions/sin.rb
+++ b/lib/keisan/functions/sin.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        Keisan::AST::Function.new([argument], "cos")
+        AST::Function.new([argument], "cos")
       end
     end
   end

--- a/lib/keisan/functions/sinh.rb
+++ b/lib/keisan/functions/sinh.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        Keisan::AST::Function.new([argument], "cosh")
+        AST::Function.new([argument], "cosh")
       end
     end
   end

--- a/lib/keisan/functions/sqrt.rb
+++ b/lib/keisan/functions/sqrt.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        Keisan::AST::Exponent.new([argument, Rational(-1,2)]) / 2
+        AST::Exponent.new([argument, Rational(-1,2)]) / 2
       end
     end
   end

--- a/lib/keisan/functions/tan.rb
+++ b/lib/keisan/functions/tan.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        Keisan::AST::Exponent.new([Keisan::AST::Function.new([argument], "cos"), -2])
+        AST::Exponent.new([AST::Function.new([argument], "cos"), -2])
       end
     end
   end

--- a/lib/keisan/functions/tanh.rb
+++ b/lib/keisan/functions/tanh.rb
@@ -8,7 +8,7 @@ module Keisan
       protected
 
       def self.derivative(argument)
-        Keisan::AST::Exponent.new([Keisan::AST::Function.new([argument], "cosh"), -2])
+        AST::Exponent.new([AST::Function.new([argument], "cosh"), -2])
       end
     end
   end

--- a/lib/keisan/parsing/assignment.rb
+++ b/lib/keisan/parsing/assignment.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class Assignment < Operator
       def node_class
-        Keisan::AST::Assignment
+        AST::Assignment
       end
     end
   end

--- a/lib/keisan/parsing/bitwise_and.rb
+++ b/lib/keisan/parsing/bitwise_and.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class BitwiseAnd < BitwiseOperator
       def node_class
-        Keisan::AST::BitwiseAnd
+        AST::BitwiseAnd
       end
     end
   end

--- a/lib/keisan/parsing/bitwise_not.rb
+++ b/lib/keisan/parsing/bitwise_not.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class BitwiseNot < UnaryOperator
       def node_class
-        Keisan::AST::UnaryBitwiseNot
+        AST::UnaryBitwiseNot
       end
     end
   end

--- a/lib/keisan/parsing/bitwise_not_not.rb
+++ b/lib/keisan/parsing/bitwise_not_not.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class BitwiseNotNot < UnaryOperator
       def node_class
-        Keisan::AST::UnaryIdentity
+        AST::UnaryIdentity
       end
     end
   end

--- a/lib/keisan/parsing/bitwise_or.rb
+++ b/lib/keisan/parsing/bitwise_or.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class BitwiseOr < BitwiseOperator
       def node_class
-        Keisan::AST::BitwiseOr
+        AST::BitwiseOr
       end
     end
   end

--- a/lib/keisan/parsing/bitwise_xor.rb
+++ b/lib/keisan/parsing/bitwise_xor.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class BitwiseXor < BitwiseOperator
       def node_class
-        Keisan::AST::BitwiseXor
+        AST::BitwiseXor
       end
     end
   end

--- a/lib/keisan/parsing/divide.rb
+++ b/lib/keisan/parsing/divide.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class Divide < ArithmeticOperator
       def node_class
-        Keisan::AST::Times
+        AST::Times
       end
     end
   end

--- a/lib/keisan/parsing/exponent.rb
+++ b/lib/keisan/parsing/exponent.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class Exponent < ArithmeticOperator
       def node_class
-        Keisan::AST::Exponent
+        AST::Exponent
       end
     end
   end

--- a/lib/keisan/parsing/group.rb
+++ b/lib/keisan/parsing/group.rb
@@ -4,7 +4,7 @@ module Keisan
       attr_reader :components
 
       def initialize(sub_tokens)
-        @components = Keisan::Parser.new(tokens: sub_tokens).components
+        @components = Parser.new(tokens: sub_tokens).components
       end
     end
   end

--- a/lib/keisan/parsing/indexing.rb
+++ b/lib/keisan/parsing/indexing.rb
@@ -7,7 +7,7 @@ module Keisan
       end
 
       def node_class
-        Keisan::AST::Indexing
+        AST::Indexing
       end
     end
   end

--- a/lib/keisan/parsing/logical_and.rb
+++ b/lib/keisan/parsing/logical_and.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class LogicalAnd < LogicalOperator
       def node_class
-        Keisan::AST::LogicalAnd
+        AST::LogicalAnd
       end
     end
   end

--- a/lib/keisan/parsing/logical_equal.rb
+++ b/lib/keisan/parsing/logical_equal.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class LogicalEqual < LogicalOperator
       def node_class
-        Keisan::AST::LogicalEqual
+        AST::LogicalEqual
       end
     end
   end

--- a/lib/keisan/parsing/logical_greater_than.rb
+++ b/lib/keisan/parsing/logical_greater_than.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class LogicalGreaterThan < LogicalOperator
       def node_class
-        Keisan::AST::LogicalGreaterThan
+        AST::LogicalGreaterThan
       end
     end
   end

--- a/lib/keisan/parsing/logical_greater_than_or_equal_to.rb
+++ b/lib/keisan/parsing/logical_greater_than_or_equal_to.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class LogicalGreaterThanOrEqualTo < LogicalOperator
       def node_class
-        Keisan::AST::LogicalGreaterThanOrEqualTo
+        AST::LogicalGreaterThanOrEqualTo
       end
     end
   end

--- a/lib/keisan/parsing/logical_less_than.rb
+++ b/lib/keisan/parsing/logical_less_than.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class LogicalLessThan < LogicalOperator
       def node_class
-        Keisan::AST::LogicalLessThan
+        AST::LogicalLessThan
       end
     end
   end

--- a/lib/keisan/parsing/logical_less_than_or_equal_to.rb
+++ b/lib/keisan/parsing/logical_less_than_or_equal_to.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class LogicalLessThanOrEqualTo < LogicalOperator
       def node_class
-        Keisan::AST::LogicalLessThanOrEqualTo
+        AST::LogicalLessThanOrEqualTo
       end
     end
   end

--- a/lib/keisan/parsing/logical_not.rb
+++ b/lib/keisan/parsing/logical_not.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class LogicalNot < UnaryOperator
       def node_class
-        Keisan::AST::UnaryLogicalNot
+        AST::UnaryLogicalNot
       end
     end
   end

--- a/lib/keisan/parsing/logical_not_equal.rb
+++ b/lib/keisan/parsing/logical_not_equal.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class LogicalNotEqual < LogicalOperator
       def node_class
-        Keisan::AST::LogicalNotEqual
+        AST::LogicalNotEqual
       end
     end
   end

--- a/lib/keisan/parsing/logical_not_not.rb
+++ b/lib/keisan/parsing/logical_not_not.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class LogicalNotNot < UnaryOperator
       def node_class
-        Keisan::AST::UnaryIdentity
+        AST::UnaryIdentity
       end
     end
   end

--- a/lib/keisan/parsing/logical_or.rb
+++ b/lib/keisan/parsing/logical_or.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class LogicalOr < LogicalOperator
       def node_class
-        Keisan::AST::LogicalOr
+        AST::LogicalOr
       end
     end
   end

--- a/lib/keisan/parsing/minus.rb
+++ b/lib/keisan/parsing/minus.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class Minus < ArithmeticOperator
       def node_class
-        Keisan::AST::Plus
+        AST::Plus
       end
     end
   end

--- a/lib/keisan/parsing/modulo.rb
+++ b/lib/keisan/parsing/modulo.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class Modulo < ArithmeticOperator
       def node_class
-        Keisan::AST::Modulo
+        AST::Modulo
       end
     end
   end

--- a/lib/keisan/parsing/operator.rb
+++ b/lib/keisan/parsing/operator.rb
@@ -14,7 +14,7 @@ module Keisan
       end
 
       def node_class
-        raise Keisan::Exceptions::NotImplementedError.new
+        raise Exceptions::NotImplementedError.new
       end
     end
   end

--- a/lib/keisan/parsing/plus.rb
+++ b/lib/keisan/parsing/plus.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class Plus < ArithmeticOperator
       def node_class
-        Keisan::AST::Plus
+        AST::Plus
       end
     end
   end

--- a/lib/keisan/parsing/times.rb
+++ b/lib/keisan/parsing/times.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class Times < ArithmeticOperator
       def node_class
-        Keisan::AST::Times
+        AST::Times
       end
     end
   end

--- a/lib/keisan/parsing/unary_minus.rb
+++ b/lib/keisan/parsing/unary_minus.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class UnaryMinus < UnaryOperator
       def node_class
-        Keisan::AST::UnaryMinus
+        AST::UnaryMinus
       end
     end
   end

--- a/lib/keisan/parsing/unary_operator.rb
+++ b/lib/keisan/parsing/unary_operator.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class UnaryOperator < Operator
       def node_class
-        raise Keisan::Exponent::NotImplementedError.new
+        raise Exponent::NotImplementedError.new
       end
     end
   end

--- a/lib/keisan/parsing/unary_plus.rb
+++ b/lib/keisan/parsing/unary_plus.rb
@@ -2,7 +2,7 @@ module Keisan
   module Parsing
     class UnaryPlus < UnaryOperator
       def node_class
-        Keisan::AST::UnaryPlus
+        AST::UnaryPlus
       end
     end
   end

--- a/lib/keisan/repl.rb
+++ b/lib/keisan/repl.rb
@@ -20,7 +20,7 @@ module Keisan
     end
 
     def reset
-      @calculator = Keisan::Calculator.new
+      @calculator = Calculator.new
     end
 
     def start

--- a/lib/keisan/tokenizer.rb
+++ b/lib/keisan/tokenizer.rb
@@ -34,11 +34,11 @@ module Keisan
       expression = expression.gsub(/\n/, ";")
 
       # Do not allow whitespace between variables, numbers, and the like; they must be joined by operators
-      raise Keisan::Exceptions::TokenizingError.new if expression.gsub(Tokens::String.regex, "").match /\w\s+\w/
+      raise Exceptions::TokenizingError.new if expression.gsub(Tokens::String.regex, "").match /\w\s+\w/
 
       # Only strip whitespace outside of strings, e.g.
       # "1 + 2 + 'hello world'" => "1+2+'hello world'"
-      expression.split(Keisan::Tokens::String.regex).map.with_index {|s,i| i.even? ? s.gsub(/\s+/, "") : s}.join
+      expression.split(Tokens::String.regex).map.with_index {|s,i| i.even? ? s.gsub(/\s+/, "") : s}.join
     end
 
     private
@@ -54,7 +54,7 @@ module Keisan
       end
 
       unless tokenizing_check == @expression
-        raise Keisan::Exceptions::TokenizingError.new("Expected \"#{@expression}\", tokenized \"#{tokenizing_check}\"")
+        raise Exceptions::TokenizingError.new("Expected \"#{@expression}\", tokenized \"#{tokenizing_check}\"")
       end
 
       tokens

--- a/lib/keisan/variables/registry.rb
+++ b/lib/keisan/variables/registry.rb
@@ -16,14 +16,14 @@ module Keisan
 
       def [](name)
         return @hash[name] if @hash.has_key?(name)
-        raise Keisan::Exceptions::UndefinedVariableError.new if @shadowed.include?(name)
+        raise Exceptions::UndefinedVariableError.new if @shadowed.include?(name)
 
         if @parent && (parent_value = @parent[name])
           return parent_value
         end
 
         return default_registry[name] if @use_defaults && default_registry.has_name?(name)
-        raise Keisan::Exceptions::UndefinedVariableError.new name
+        raise Exceptions::UndefinedVariableError.new name
       end
 
       def locals
@@ -32,17 +32,17 @@ module Keisan
 
       def has?(name)
         !self[name].nil?
-      rescue Keisan::Exceptions::UndefinedVariableError
+      rescue Exceptions::UndefinedVariableError
         false
       end
 
       def register!(name, value, force: false)
         name = name.to_s
-        name = name.name if name.is_a?(Keisan::AST::Variable)
+        name = name.name if name.is_a?(AST::Variable)
 
-        raise Keisan::Exceptions::UnmodifiableError.new("Cannot modify frozen variables registry") if frozen?
+        raise Exceptions::UnmodifiableError.new("Cannot modify frozen variables registry") if frozen?
         if !force && @use_defaults && default_registry.has_name?(name)
-          raise Keisan::Exceptions::UnmodifiableError.new("Cannot overwrite default variable")
+          raise Exceptions::UnmodifiableError.new("Cannot overwrite default variable")
         end
         self[name.to_s] = value.to_node
       end


### PR DESCRIPTION
Great gem!!!

I noticed while reading the code that "Keisan" and other parent module names are sprinkled across the code when they aren't really necessary, since in most cases they are implied by the context. I tried removing them and specs still pass, so... I think this is ok.

Actually, I think there's more you can probably remove :smile: also I may have gone too far in a spot or two, you should double-check the code is still using the correct classes/modules. But tests pass so I guess everything is ok!