### PR TITLE
`evaluate` should not evaluate RHS of assignment

### DIFF
--- a/lib/keisan/ast/assignment.rb
+++ b/lib/keisan/ast/assignment.rb
@@ -24,6 +24,10 @@ module Keisan
         evaluate(context)
       end
 
+      def evaluate_assignments(context = nil)
+        evaluate(context)
+      end
+
       def unbound_variables(context = nil)
         variables = super(context)
         if is_variable_definition?
@@ -86,7 +90,7 @@ module Keisan
           Functions::ExpressionFunction.new(
             lhs.name,
             argument_names,
-            rhs.simplify(function_definition_context),
+            rhs.evaluate_assignments(function_definition_context),
             context.transient_definitions
           )
         )

--- a/lib/keisan/ast/function.rb
+++ b/lib/keisan/ast/function.rb
@@ -23,6 +23,10 @@ module Keisan
         context.has_function?(name) ? functions : functions | Set.new([name])
       end
 
+      def evaluate_assignments(context = nil)
+        self
+      end
+
       def function_defined?(context = nil)
         context ||= Context.new
         context.has_function?(name)

--- a/lib/keisan/ast/indexing.rb
+++ b/lib/keisan/ast/indexing.rb
@@ -16,6 +16,10 @@ module Keisan
         "(#{child.to_s})[#{indexes.map(&:to_s).join(',')}]"
       end
 
+      def evaluate_assignments(context = nil)
+        self
+      end
+
       def evaluate(context = nil)
         context ||= Context.new
         @children = children.map {|child| child.evaluate(context)}

--- a/lib/keisan/ast/multi_line.rb
+++ b/lib/keisan/ast/multi_line.rb
@@ -6,6 +6,14 @@ module Keisan
         evaluate(context).value(context)
       end
 
+      def evaluate_assignments(context = nil)
+        context ||= Context.new
+        @children = children.map do |child|
+          child.evaluate_assignments(context)
+        end
+        self
+      end
+
       def evaluate(context = nil)
         context ||= Keisan::Context.new
         @children = children.map {|child| child.evaluate(context)}

--- a/lib/keisan/ast/node.rb
+++ b/lib/keisan/ast/node.rb
@@ -37,6 +37,10 @@ module Keisan
         self
       end
 
+      def evaluate_assignments(context = nil)
+        self
+      end
+
       def differentiate(variable, context = nil)
         raise Exceptions::NonDifferentiableError.new
       end

--- a/lib/keisan/ast/operator.rb
+++ b/lib/keisan/ast/operator.rb
@@ -47,6 +47,14 @@ module Keisan
         @parsing_operators = parsing_operators
       end
 
+      def evaluate_assignments(context = nil)
+        context ||= Context.new
+        @children = children.map do |child|
+          child.evaluate_assignments(context)
+        end
+        self
+      end
+
       def self.associativity_of_priority(priority)
         ASSOCIATIVITY_OF_PRIORITY[priority]
       end

--- a/lib/keisan/functions/expression_function.rb
+++ b/lib/keisan/functions/expression_function.rb
@@ -41,7 +41,7 @@ module Keisan
           local.register_variable!(arg_name, argument_values[i].evaluate(context))
         end
 
-        expression.evaluate(local)
+        expression.evaluated(local)
       end
 
       def simplify(ast_function, context = nil)

--- a/spec/keisan/ast/assignment_spec.rb
+++ b/spec/keisan/ast/assignment_spec.rb
@@ -35,22 +35,30 @@ RSpec.describe Keisan::AST::Assignment do
         f = calculator.context.function("f")
         g = calculator.context.function("g")
 
+        expect(calculator.evaluate("f(1)")).to eq 4
+        expect(calculator.evaluate("f(2)")).to eq 7
+        expect(calculator.evaluate("g(1)")).to eq 7
+        expect(calculator.evaluate("g(2)")).to eq 9
+
         expect(f).to be_a(Keisan::Functions::ExpressionFunction)
         expect(g).to be_a(Keisan::Functions::ExpressionFunction)
 
         expect(f.expression).to be_a(Keisan::AST::Plus)
-        expect(f.expression.children[0]).to be_a(Keisan::AST::Number)
-        expect(f.expression.children[0].value).to eq 1
-        expect(f.expression.children[1]).to be_a(Keisan::AST::Times)
+        expect(f.expression.children[0]).to be_a(Keisan::AST::Times)
+        expect(f.expression.children[1]).to be_a(Keisan::AST::Number)
+        expect(f.expression.children[1].value).to eq 1
 
-        expect(f.expression.children[1].children[0]).to be_a(Keisan::AST::Number)
-        expect(f.expression.children[1].children[0].value).to eq 3
-        expect(f.expression.children[1].children[1]).to be_a(Keisan::AST::Variable)
-        expect(f.expression.children[1].children[1].name).to eq "x"
+        expect(f.expression.children[0].children[0]).to be_a(Keisan::AST::Number)
+        expect(f.expression.children[0].children[0].value).to eq 3
+        expect(f.expression.children[0].children[1]).to be_a(Keisan::AST::Variable)
+        expect(f.expression.children[0].children[1].name).to eq "x"
 
         expect(g.expression).to be_a(Keisan::AST::Plus)
-        expect(g.expression.children[0]).to be_a(Keisan::AST::Number)
-        expect(g.expression.children[0].value).to eq 5
+        expect(g.expression.children[0]).to be_a(Keisan::AST::Plus)
+        expect(g.expression.children[0].children[0]).to be_a(Keisan::AST::Number)
+        expect(g.expression.children[0].children[0].value).to eq 2
+        expect(g.expression.children[0].children[1]).to be_a(Keisan::AST::Variable)
+        expect(g.expression.children[0].children[1].name).to eq "n"
         expect(g.expression.children[1]).to be_a(Keisan::AST::Function)
         expect(g.expression.children[1].name).to eq "h"
         expect(g.expression.children[1].children.map(&:name)).to match_array(["x"])

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Keisan::Calculator do
         expect(calculator.evaluate("f(3)")).to eq (60 + 3**2)
         calculator.evaluate("a = 3")
         calculator.evaluate("g(x) = 0")
-        expect(calculator.evaluate("f(3)")).to eq (60 + 3**2)
+        expect(calculator.evaluate("f(3)")).to eq (90 + 3**2)
       end
     end
 


### PR DESCRIPTION
This change evaluates only assignments of the RHS of assignments.  We want to leave the RHS of a function definition alone.