### PR TITLE
`let` keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ For looping, you can use the basic `while` loop, which has an expression that ev
 
 ```ruby
 calculator = Keisan::Calculator.new
-calculator.evaluate("my_sum(a_) = {i_ = 0; total_ = 0; while(i_ < a_.size, {total_ = total_ + a_[i_]; i_ = i_ + 1}); total_}")
+calculator.evaluate("my_sum(a) = {let i = 0; let total = 0; while(i < a.size, {total = total + a[i]; i = i + 1}); total}")
 calculator.evaluate("my_sum([1,3,5,7,9])")
 #=> 25
 ```

--- a/README.md
+++ b/README.md
@@ -196,6 +196,16 @@ calculator.evaluate("a")
 #=> Keisan::Exceptions::UndefinedVariableError: a
 ```
 
+By default assigning to a variable or function will bubble up to the first definition available in the parent scopes.  To assign to a local variable, you can use the `let` keyword.  The difference is illustrated below.
+
+```ruby
+calculator = Keisan::Calculator.new
+calculator.evaluate("x = 1; {x = 2}; x")
+#=> 2
+calculator.evaluate("x = 11; {let x = 12}; x")
+#=> 11
+```
+
 ##### Lists
 
 Just like in Ruby, lists can be defined using square brackets, and indexed using square brackets

--- a/lib/keisan/ast/assignment.rb
+++ b/lib/keisan/ast/assignment.rb
@@ -1,6 +1,13 @@
 module Keisan
   module AST
     class Assignment < Operator
+      attr_reader :local
+
+      def initialize(children = [], parsing_operators = [], local: false)
+        super(children, parsing_operators)
+        @local = local
+      end
+
       def self.symbol
         :"="
       end
@@ -64,7 +71,7 @@ module Keisan
         end
 
         rhs_value = rhs.value(context)
-        context.register_variable!(lhs.name, rhs_value)
+        context.register_variable!(lhs.name, rhs_value, local: local)
         # Return the variable assigned value
         rhs
       end
@@ -94,7 +101,8 @@ module Keisan
             argument_names,
             rhs.evaluate_assignments(function_definition_context),
             context.transient_definitions
-          )
+          ),
+          local: local
         )
 
         rhs

--- a/lib/keisan/context.rb
+++ b/lib/keisan/context.rb
@@ -61,8 +61,8 @@ module Keisan
       @variable_registry.has?(name)
     end
 
-    def register_variable!(name, value)
-      if !@variable_registry.shadowed.member?(name) && (transient? || @parent&.has_variable?(name))
+    def register_variable!(name, value, local: false)
+      if !@variable_registry.shadowed.member?(name) && (transient? || !local && @parent&.has_variable?(name))
         @parent.register_variable!(name, value)
       else
         @variable_registry.register!(name, value)
@@ -77,8 +77,8 @@ module Keisan
       @function_registry.has?(name)
     end
 
-    def register_function!(name, function)
-      if transient? || @parent&.has_function?(name)
+    def register_function!(name, function, local: false)
+      if transient? || !local && @parent&.has_function?(name)
         @parent.register_function!(name, function)
       else
         @function_registry.register!(name.to_s, function)

--- a/lib/keisan/functions/default_registry.rb
+++ b/lib/keisan/functions/default_registry.rb
@@ -1,3 +1,5 @@
+require_relative "let"
+
 require_relative "if"
 require_relative "while"
 require_relative "diff"
@@ -41,6 +43,8 @@ module Keisan
       private
 
       def self.register_defaults!(registry)
+        registry.register!(:let, Let.new, force: true)
+
         registry.register!(:if, If.new, force: true)
         registry.register!(:while, While.new, force: true)
         registry.register!(:diff, Diff.new, force: true)

--- a/lib/keisan/functions/let.rb
+++ b/lib/keisan/functions/let.rb
@@ -1,0 +1,38 @@
+module Keisan
+  module Functions
+    class Let < Keisan::Function
+      def initialize
+        super("let", Range.new(1,2))
+      end
+
+      def value(ast_function, context = nil)
+        validate_arguments!(ast_function.children.count)
+        assignment(ast_function).value(context)
+      end
+
+      def evaluate(ast_function, context = nil)
+        validate_arguments!(ast_function.children.count)
+        assignment(ast_function).evaluate(context)
+      end
+
+      def simplify(ast_function, context = nil)
+        validate_arguments!(ast_function.children.count)
+        assignment(ast_function).simplify(context)
+      end
+
+      private
+
+      def assignment(ast_function)
+        if ast_function.children.count == 1
+          unless ast_function.children.first.is_a?(AST::Assignment)
+            raise Exceptions::InvalidFunctionError.new("`let` must accept assignment if given one argument")
+          end
+
+          AST::Assignment.new(ast_function.children.first.children, local: true)
+        else
+          AST::Assignment.new(ast_function.children, local: true)
+        end
+      end
+    end
+  end
+end

--- a/lib/keisan/parser.rb
+++ b/lib/keisan/parser.rb
@@ -1,5 +1,7 @@
 module Keisan
   class Parser
+    KEYWORDS = %w(let).freeze
+
     attr_reader :tokens, :components
 
     def initialize(string: nil, tokens: nil)
@@ -16,8 +18,12 @@ module Keisan
 
       @components = []
 
-      parse_components!
-      remove_unary_identity!
+      if @tokens.first&.is_a?(Tokens::Word) && KEYWORDS.include?(@tokens.first.string)
+        parse_keyword!
+      else
+        parse_components!
+        remove_unary_identity!
+      end
     end
 
     def ast
@@ -25,6 +31,13 @@ module Keisan
     end
 
     private
+
+    def parse_keyword!
+      keyword = tokens.first.string
+      @components = [
+        Parsing::Function.new(keyword, Parsing::Argument.new(tokens[1..-1]))
+      ]
+    end
 
     def parse_components!
       @unparsed_tokens = tokens.dup

--- a/lib/keisan/parsing/function.rb
+++ b/lib/keisan/parsing/function.rb
@@ -5,7 +5,7 @@ module Keisan
 
       def initialize(name, arguments)
         @name = name
-        @arguments = arguments
+        @arguments = Array.wrap(arguments)
       end
     end
   end

--- a/lib/keisan/tokenizer.rb
+++ b/lib/keisan/tokenizer.rb
@@ -33,12 +33,9 @@ module Keisan
       expression = expression.split("#").first || ""
       expression = expression.gsub(/\n/, ";")
 
-      # Do not allow whitespace between variables, numbers, and the like; they must be joined by operators
-      raise Exceptions::TokenizingError.new if expression.gsub(Tokens::String.regex, "").match /\w\s+\w/
-
       # Only strip whitespace outside of strings, e.g.
       # "1 + 2 + 'hello world'" => "1+2+'hello world'"
-      expression.split(Tokens::String.regex).map.with_index {|s,i| i.even? ? s.gsub(/\s+/, "") : s}.join
+      expression.split(Tokens::String.regex).map.with_index {|s,i| i.even? ? s.gsub(/\s+/, " ") : s}.join
     end
 
     private
@@ -51,10 +48,6 @@ module Keisan
         token_string = scan_result[i]
         tokenizing_check << token_string
         token_class = TOKEN_CLASSES[i].new(token_string)
-      end
-
-      unless tokenizing_check == @expression
-        raise Exceptions::TokenizingError.new("Expected \"#{@expression}\", tokenized \"#{tokenizing_check}\"")
       end
 
       tokens

--- a/spec/keisan/ast/builder_spec.rb
+++ b/spec/keisan/ast/builder_spec.rb
@@ -106,5 +106,10 @@ RSpec.describe Keisan::AST::Builder do
       ast = described_class.new(string: "f(x;,;y;;) = 5+x; f(1+2,50)**2").ast
       expect(ast.value).to eq 64
     end
+
+    it "works with blocks and new lines too" do
+      ast = described_class.new(string: "{let x = 5; x}").ast
+      expect(ast.to_s).to eq "{let(x=5);x}"
+    end
   end
 end

--- a/spec/keisan/ast/node_spec.rb
+++ b/spec/keisan/ast/node_spec.rb
@@ -345,7 +345,7 @@ RSpec.describe Keisan::AST::Node do
     it "works nested" do
       calculator = Keisan::Calculator.new
 
-      calculator.evaluate("my_sum(list) = {i = 0; total = 0; while(i < list.size, {total = total + list[i]; i = i+1}); total}")
+      calculator.evaluate("my_sum(list) = {let i = 0; let total = 0; while(i < list.size, {total = total + list[i]; i = i+1}); total}")
       expect(calculator.evaluate("my_sum([1,3,5,7])")).to eq 16
     end
 

--- a/spec/keisan/context_spec.rb
+++ b/spec/keisan/context_spec.rb
@@ -222,4 +222,40 @@ RSpec.describe Keisan::Context do
       expect(my_context.variable("x").value).to eq 123
     end
   end
+
+  describe "local variables/functions" do
+    context "variables" do
+      it "does not bubble up to definition defined at parent context" do
+        parent = described_class.new
+        child  = parent.spawn_child(transient: false)
+
+        parent.register_variable!("x", 1)
+        child.register_variable!("x", 2)
+
+        expect(parent.variable("x").value).to eq 2
+
+        child.register_variable!("x", 3, local: true)
+
+        expect(parent.variable("x").value).to eq 2
+        expect(child.variable("x").value).to eq 3
+      end
+    end
+
+    context "functions" do
+      it "does not bubble up to definition defined at parent context" do
+        parent = described_class.new
+        child  = parent.spawn_child(transient: false)
+
+        parent.register_function!("f", Proc.new {|x| 1})
+        child.register_function!("f", Proc.new {|x| 2})
+
+        expect(parent.function("f").call(nil, 100).value).to eq 2
+
+        child.register_function!("f", Proc.new {|x| 3}, local: true)
+
+        expect(parent.function("f").call(nil, 100).value).to eq 2
+        expect(child.function("f").call(nil, 100).value).to eq 3
+      end
+    end
+  end
 end

--- a/spec/keisan/let_spec.rb
+++ b/spec/keisan/let_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe Keisan::Functions::Let do
+  it "can be used to assign variables" do
+    calculator = Keisan::Calculator.new
+    calculator.evaluate("let x = 4")
+    expect(calculator.evaluate("2*x")).to eq 8
+  end
+
+  it "defines variables locally when in block" do
+    calculator = Keisan::Calculator.new
+    calculator.evaluate("let x = 7")
+
+    expect(calculator.evaluate("{let x = 11; x*2}")).to eq 22
+    expect(calculator.evaluate("x")).to eq 7
+  end
+end

--- a/spec/keisan/parser_spec.rb
+++ b/spec/keisan/parser_spec.rb
@@ -604,5 +604,18 @@ RSpec.describe Keisan::Parser do
         ])
       end
     end
+
+    context "keyword" do
+      it "parses the keyword into a function call" do
+        parser = described_class.new(string: "let x = 5")
+        expect(parser.components.map(&:class)).to eq([Keisan::Parsing::Function])
+        expect(parser.components.first.arguments.count).to eq 1
+        expect(parser.components.first.arguments.first.components.map(&:class)).to eq([
+          Keisan::Parsing::Variable,
+          Keisan::Parsing::Assignment,
+          Keisan::Parsing::Number
+        ])
+      end
+    end
   end
 end

--- a/spec/keisan/tokenizer_spec.rb
+++ b/spec/keisan/tokenizer_spec.rb
@@ -1,12 +1,6 @@
 require "spec_helper"
 
 RSpec.describe Keisan::Tokenizer do
-  context "invalid symbols" do
-    it "raises a TokenizingError" do
-      expect { described_class.new("1 1") }.to raise_error(Keisan::Exceptions::TokenizingError)
-    end
-  end
-
   context "numbers" do
     context "integer" do
       it "gets integers correctly" do
@@ -166,7 +160,7 @@ RSpec.describe Keisan::Tokenizer do
   context "nested groups" do
     context "empty group" do
       it "has no sub tokens" do
-        tokenizer = described_class.new("(  )")
+        tokenizer = described_class.new("()")
         expect(tokenizer.tokens.count).to eq 1
         token = tokenizer.tokens.first
         expect(token).to be_a(Keisan::Tokens::Group)
@@ -177,7 +171,7 @@ RSpec.describe Keisan::Tokenizer do
 
     context "mixed braces" do
       it "works as expected" do
-        tokenizer = described_class.new("1 + (x - [ 3+4 ] + 5) - [6,7](8)")
+        tokenizer = described_class.new("1+(x-[3+4]+5)-[6,7](8)")
 
         expect(tokenizer.tokens.map(&:class)).to match_array([
           Keisan::Tokens::Number,
@@ -230,7 +224,7 @@ RSpec.describe Keisan::Tokenizer do
     end
 
     it "has nested groups properly tokenized" do
-      tokenizer = described_class.new("1 + (2 + (3+4) + 5) + (6)")
+      tokenizer = described_class.new("1+(2+(3+4)+5)+(6)")
 
       expect(tokenizer.tokens.map(&:class)).to match_array([
         Keisan::Tokens::Number,
@@ -265,7 +259,7 @@ RSpec.describe Keisan::Tokenizer do
     end
 
     it "handles non nested groups properly" do
-      tokenizer = described_class.new("(1 + 2) * (3 + 4)")
+      tokenizer = described_class.new("(1+2)*(3+4)")
 
       expect(tokenizer.tokens.map(&:class)).to match_array([
         Keisan::Tokens::Group,
@@ -299,7 +293,7 @@ RSpec.describe Keisan::Tokenizer do
     end
 
     it "gets correct operators" do
-      tokenizer = described_class.new("!false || true && (1 < 2)")
+      tokenizer = described_class.new("!false || true && (1<2)")
 
       expect(tokenizer.tokens.map(&:class)).to match_array([
         Keisan::Tokens::LogicalOperator,
@@ -333,7 +327,7 @@ RSpec.describe Keisan::Tokenizer do
 
   context "bitwise operators" do
     it "gets correct operators" do
-      tokenizer = described_class.new("~x ^ (7 | 2) & 4")
+      tokenizer = described_class.new("~x ^ (7|2) & 4")
 
       expect(tokenizer.tokens.map(&:class)).to match_array([
         Keisan::Tokens::BitwiseOperator,
@@ -469,6 +463,20 @@ RSpec.describe Keisan::Tokenizer do
       expect(tokenizer.tokens[0].value).to eq 1
       expect(tokenizer.tokens[2].string).to eq "x"
       expect(tokenizer.tokens[4].value).to eq 3
+    end
+  end
+
+  context "function call" do
+    it "parses correctly" do
+      tokenizer = described_class.new("foo bar 11, 22")
+
+      expect(tokenizer.tokens.map(&:class)).to eq([
+        Keisan::Tokens::Word,
+        Keisan::Tokens::Word,
+        Keisan::Tokens::Number,
+        Keisan::Tokens::Comma,
+        Keisan::Tokens::Number
+      ])
     end
   end
 end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "README.md" do
       digest = Digest::SHA256.hexdigest(content)
 
       # cat README.md | sha256sum
-      expected_digest = "bff27e2a84f29d6151874c71e7586b896c9ebc23205b989637806ca4aea96dee"
+      expected_digest = "91c3763815274bc724d19a990137eccd778270c9f174c1b2aaf524bae978c960"
       if digest != expected_digest
         raise "Invalid README file detected with SHA256 digest of #{digest}. Use command `cat README.md | sha256sum` to get correct digest if your changes to the README are safe. Aborting README test."
       end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe "README.md" do
       digest = Digest::SHA256.hexdigest(content)
 
       # cat README.md | sha256sum
-      expected_digest = "ff134348e5eb361b5b6db49f83dc2d9456987bb6173af2af14623107716528b2"
+      expected_digest = "bff27e2a84f29d6151874c71e7586b896c9ebc23205b989637806ca4aea96dee"
       if digest != expected_digest
-        raise "Invalid README file detected with SHA256 digest of #{digest}, aborting README test"
+        raise "Invalid README file detected with SHA256 digest of #{digest}. Use command `cat README.md | sha256sum` to get correct digest if your changes to the README are safe. Aborting README test."
       end
 
       content.scan(/^```ruby$\n(?<block>(?:^.*?$\n)*?)^```$/m).map {|match| match[0].split("\n").map(&:strip)}


### PR DESCRIPTION
Currently variables are all essentially globally defined.  This PR adds the `let` keyword that makes it so assignment to a variable/function will not bubble up to the parent context.  The difference between using `let` or not can be seen in the following:

```
keisan> x = 1; {x = 2}; x
=> 2
keisan> x = 1; {let x = 2}; x
=> 1
```

In the first case, inside the brace changing `x` changes it in the upper scope, but in the second case using `let` forces the assignment to only be local to the block.