### PR TITLE
Add useful module methods for Keisan

### DIFF
--- a/lib/keisan.rb
+++ b/lib/keisan.rb
@@ -140,4 +140,27 @@ require "keisan/calculator"
 require "keisan/evaluator"
 
 module Keisan
+  def self.calculator
+    @@calculator ||= Calculator.new
+  end
+
+  def self.reset
+    @@calculator = nil
+  end
+
+  def self.[](expression)
+    simplify(expression)
+  end
+
+  def self.evaluate(expression)
+    calculator.evaluate(expression)
+  end
+
+  def self.simplify(expression)
+    calculator.simplify(expression)
+  end
+
+  def self.ast(expression)
+    calculator.ast(expression)
+  end
 end

--- a/lib/keisan/ast/constant_literal.rb
+++ b/lib/keisan/ast/constant_literal.rb
@@ -5,6 +5,15 @@ module Keisan
         self
       end
 
+      def ==(other)
+        case other
+        when ConstantLiteral
+          value == other.value
+        else
+          false
+        end
+      end
+
       def to_s
         case value
         when Rational

--- a/lib/keisan/ast/literal.rb
+++ b/lib/keisan/ast/literal.rb
@@ -1,14 +1,6 @@
 module Keisan
   module AST
     class Literal < Node
-      def ==(other)
-        case other
-        when Literal
-          value == other.value
-        else
-          false
-        end
-      end
     end
   end
 end

--- a/lib/keisan/ast/variable.rb
+++ b/lib/keisan/ast/variable.rb
@@ -18,7 +18,12 @@ module Keisan
       end
 
       def ==(other)
-        name == other.name
+        case other
+        when Variable
+          name == other.name
+        else
+          false
+        end
       end
 
       def to_s

--- a/spec/keisan_spec.rb
+++ b/spec/keisan_spec.rb
@@ -4,4 +4,59 @@ RSpec.describe Keisan do
   it "has a version number" do
     expect(Keisan::VERSION).to eq "0.5.0"
   end
+
+  context "module methods" do
+    after do
+      # Want to reset the calculator internal to Keisan after each spec
+      # so specs do not interfere
+      Keisan.reset
+    end
+
+    describe "calculator" do
+      it "has a calculator for use" do
+        expect(Keisan.calculator).to be_a(Keisan::Calculator)
+        Keisan.calculator.evaluate("x = 5")
+        expect(Keisan["x"].value).to eq 5
+      end
+
+      it "is reset by #reset method" do
+        Keisan["x = 5"]
+
+        expect {
+          Keisan.reset
+        }.to change {
+          Keisan["x"]
+        }.from(Keisan::AST::Number.new(5)).to(Keisan::AST::Variable.new("x"))
+      end
+    end
+
+    describe "evaluate" do
+      it "evaluates the expression" do
+        expect(Keisan.evaluate("1+2").value).to eq 3
+        expect{Keisan.evaluate("x")}.to raise_error(Keisan::Exceptions::UndefinedVariableError)
+      end
+    end
+
+    describe "ast" do
+      it "returns the ast of the expression" do
+        ast = Keisan.ast("1+x")
+        expect(ast).to be_a(Keisan::AST::Plus)
+        expect(ast.to_s).to eq "1+x"
+      end
+    end
+
+    describe "simplify" do
+      it "simplifies the expression" do
+        expect(Keisan.simplify("0*x").value).to eq 0
+        expect(Keisan.simplify("x")).to eq Keisan::AST::Variable.new("x")
+      end
+    end
+
+    describe "[] method" do
+      it "simplifies" do
+        expect(Keisan["0*x"].value).to eq 0
+        expect(Keisan["x"]).to eq Keisan::AST::Variable.new("x")
+      end
+    end
+  end
 end


### PR DESCRIPTION
`Keisan` module now contains an internal `Calculator` that can be readily accessed for quick console testing.

```
Keisan["1 + 2"]
#=> 3
```