### PR TITLE
Allow local definitions to shadow defaults

### DIFF
--- a/lib/keisan/context.rb
+++ b/lib/keisan/context.rb
@@ -14,6 +14,12 @@ module Keisan
       @allow_recursive = true
     end
 
+    def freeze
+      super
+      @function_registry.freeze
+      @variable_registry.freeze
+    end
+
     # A transient context does not persist variables and functions in this context, but
     # rather store them one level higher in the parent context.  When evaluating a string,
     # the entire operation is done in a transient context that is unique from the calculators

--- a/lib/keisan/context.rb
+++ b/lib/keisan/context.rb
@@ -61,8 +61,12 @@ module Keisan
       @variable_registry.has?(name)
     end
 
+    def variable_is_modifiable?(name)
+      @variable_registry.modifiable?(name)
+    end
+
     def register_variable!(name, value, local: false)
-      if !@variable_registry.shadowed.member?(name) && (transient? || !local && @parent&.has_variable?(name))
+      if !@variable_registry.shadowed.member?(name) && (transient? || !local && @parent&.variable_is_modifiable?(name))
         @parent.register_variable!(name, value)
       else
         @variable_registry.register!(name, value)
@@ -77,8 +81,12 @@ module Keisan
       @function_registry.has?(name)
     end
 
+    def function_is_modifiable?(name)
+      @function_registry.modifiable?(name)
+    end
+
     def register_function!(name, function, local: false)
-      if transient? || !local && @parent&.has_function?(name)
+      if transient? || !local && @parent&.function_is_modifiable?(name)
         @parent.register_function!(name, function)
       else
         @function_registry.register!(name.to_s, function)

--- a/lib/keisan/functions/registry.rb
+++ b/lib/keisan/functions/registry.rb
@@ -32,13 +32,13 @@ module Keisan
         false
       end
 
+      def modifiable?(name)
+        !frozen? && has?(name)
+      end
+
       def register!(name, function, force: false)
         raise Exceptions::UnmodifiableError.new("Cannot modify frozen functions registry") if frozen?
         name = name.to_s
-
-        if !force && @use_defaults && default_registry.has_name?(name)
-          raise Exceptions::UnmodifiableError.new("Cannot overwrite default function")
-        end
 
         case function
         when Proc

--- a/lib/keisan/variables/registry.rb
+++ b/lib/keisan/variables/registry.rb
@@ -36,14 +36,15 @@ module Keisan
         false
       end
 
+      def modifiable?(name)
+        !frozen? && has?(name)
+      end
+
       def register!(name, value, force: false)
         name = name.to_s
         name = name.name if name.is_a?(AST::Variable)
 
         raise Exceptions::UnmodifiableError.new("Cannot modify frozen variables registry") if frozen?
-        if !force && @use_defaults && default_registry.has_name?(name)
-          raise Exceptions::UnmodifiableError.new("Cannot overwrite default variable")
-        end
         self[name.to_s] = AST::Cell.new(value.to_node)
       end
 

--- a/spec/keisan/context_spec.rb
+++ b/spec/keisan/context_spec.rb
@@ -17,6 +17,25 @@ RSpec.describe Keisan::Context do
     expect(my_context.function("sin")).to be_a(Keisan::Function)
   end
 
+  describe "freeze" do
+    it "freezes associated registries" do
+      frozen_context = described_class.new
+      frozen_context.register_variable!("x", 1)
+      frozen_context.register_function!("f", Proc.new {|x| x})
+      frozen_context.freeze
+
+      child_context = frozen_context.spawn_child
+      child_context.register_variable!("x", 2)
+      child_context.register_function!("f", Proc.new {|x| 2*x})
+
+      expect(frozen_context.variable("x").value).to eq 1
+      expect(child_context.variable("x").value).to eq 2
+
+      expect(frozen_context.function("f").call(nil, 3).value).to eq 3
+      expect(child_context.function("f").call(nil, 3).value).to eq 6
+    end
+  end
+
   describe "spawn_child" do
     it "has parent context's variables and functions" do
       my_context = described_class.new

--- a/spec/keisan/default_functions_spec.rb
+++ b/spec/keisan/default_functions_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe Keisan::Functions::DefaultRegistry do
     expect { registry.register!(:bad, Proc.new { false }) }.to raise_error(Keisan::Exceptions::UnmodifiableError)
   end
 
+  it "creates local function when conflicting with function in default registry" do
+    calculator = Keisan::Calculator.new
+    calculator.evaluate("sin(theta) = theta")
+
+    expect(calculator.evaluate("sin(1)").value).to eq 1
+    expect(registry["sin"].call(nil, 1).value).to eq Math.sin(1)
+  end
+
   context "array methods" do
     it "works as expected" do
       expect(registry["min"].name).to eq "min"

--- a/spec/keisan/default_variables_spec.rb
+++ b/spec/keisan/default_variables_spec.rb
@@ -16,4 +16,12 @@ RSpec.describe Keisan::Variables::DefaultRegistry do
   it "is unmodifiable" do
     expect { registry.register!(:bad, false) }.to raise_error(Keisan::Exceptions::UnmodifiableError)
   end
+
+  it "creates local variable when conflicting with variable in default registry" do
+    calculator = Keisan::Calculator.new
+    calculator.evaluate("PI = 3")
+
+    expect(calculator.evaluate("PI").value).to eq 3
+    expect(registry["PI"].value).to eq Math::PI
+  end
 end


### PR DESCRIPTION
With these changes, it is now possible to define variables/functions even if they collide with a parent context.  If the parent context's variable/function can be modified, such definitions will be modified, otherwise a new variable will be locally defined that shadows the parent one.  Variable/function definitions can be frozen by calling `freeze` on the context.