### PR TITLE
Fix interpreter to work without piped input

### DIFF
--- a/lib/keisan/interpreter.rb
+++ b/lib/keisan/interpreter.rb
@@ -1,3 +1,5 @@
+require "keisan/repl"
+
 module Keisan
   class Interpreter
     attr_reader :calculator
@@ -17,7 +19,7 @@ module Keisan
     private
 
     def run_from_stdin
-      run_on_content STDIN.read
+      run_on_content STDIN.tty? ? "" : STDIN.read
     end
 
     def run_from_file(file_name)


### PR DESCRIPTION
Currently `bin/keisan` will freeze up when given no options and no piped input, when it should really open the REPL in that case.  This fixes the problem by detecting when there is piped input or not.