### PR TITLE
Space is multiplication

### DIFF
--- a/lib/keisan.rb
+++ b/lib/keisan.rb
@@ -80,6 +80,7 @@ require "keisan/tokens/logical_operator"
 require "keisan/tokens/bitwise_operator"
 require "keisan/tokens/word"
 require "keisan/tokens/line_separator"
+require "keisan/tokens/unknown"
 
 require "keisan/tokenizer"
 

--- a/lib/keisan/parser.rb
+++ b/lib/keisan/parser.rb
@@ -119,7 +119,9 @@ module Keisan
         elsif token.type == :operator
           add_operator_to_components!(token)
         else
-          raise Exceptions::ParseError.new("Expected an operator, received #{token.string}")
+          # Concatenation is multiplication
+          @components << Parsing::Times.new
+          add_token_to_components!(token)
         end
 
       elsif @components[-1].is_a?(Parsing::Dot)

--- a/lib/keisan/tokenizer.rb
+++ b/lib/keisan/tokenizer.rb
@@ -14,7 +14,8 @@ module Keisan
       Tokens::Comma,
       Tokens::Colon,
       Tokens::Dot,
-      Tokens::LineSeparator
+      Tokens::LineSeparator,
+      Tokens::Unknown
     ]
 
     TOKEN_REGEX = Regexp::new(
@@ -45,16 +46,15 @@ module Keisan
     end
 
     def tokenize!
-      tokenizing_check = ""
-
-      tokens = @scan.map do |scan_result|
+      @scan.map do |scan_result|
         i = scan_result.find_index {|token| !token.nil?}
         token_string = scan_result[i]
-        tokenizing_check << token_string
-        token_class = TOKEN_CLASSES[i].new(token_string)
+        token = TOKEN_CLASSES[i].new(token_string)
+        if token.is_a?(Tokens::Unknown)
+          raise Keisan::Exceptions::TokenizingError.new("Unexpected token: \"#{token.string}\"")
+        end
+        token
       end
-
-      tokens
     end
   end
 end

--- a/lib/keisan/tokens/unknown.rb
+++ b/lib/keisan/tokens/unknown.rb
@@ -1,0 +1,11 @@
+module Keisan
+  module Tokens
+    class Unknown < Token
+      REGEX = /([^[[:space:]]]+?)/
+
+      def self.regex
+        REGEX
+      end
+    end
+  end
+end

--- a/spec/keisan/ast/builder_spec.rb
+++ b/spec/keisan/ast/builder_spec.rb
@@ -64,6 +64,15 @@ RSpec.describe Keisan::AST::Builder do
     end
   end
 
+  context "concatenation is multiplication" do
+    it "converts concatenated elements to multiplication" do
+      expect(described_class.new(string: "5x").ast.to_s).to eq "5*x"
+      expect(described_class.new(string: "5(1+2y)").ast.to_s).to eq "5*(1+(2*y))"
+      # Function notation takes priority
+      expect(described_class.new(string: "x(y z)").ast.to_s).to eq "x(y*z)"
+    end
+  end
+
   context "function" do
     it "properly parses" do
       expect(described_class.new(string: "sin(PI)").ast.value).to be_within(1e-10).of(0)

--- a/spec/keisan/ast/builder_spec.rb
+++ b/spec/keisan/ast/builder_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Keisan::AST::Builder do
                              }
                            KEISAN
         )
-      }.to raise_error(Keisan::Exceptions::ParseError)
+      }.to raise_error(Keisan::Exceptions::TokenizingError)
     end
   end
 end

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe Keisan::Calculator do
     expect(calculator.evaluate("2*f(x) + 4", x: 3, f: Proc.new {|x| x**2})).to eq 2*9+4
   end
 
+  context "direct concatenation is multiplication" do
+    it "works as expected in regular math notation" do
+      calculator.evaluate("x = 2; y = 3; z = 4")
+      expect(calculator.evaluate("(x+1)(y + 2z)")).to eq (2+1)*(3+2*4)
+    end
+  end
+
   context "list operations" do
     it "evaluates lists" do
       expect(calculator.evaluate("[2, 3, 5, 8]")).to eq [2,3,5,8]


### PR DESCRIPTION
In regular mathematics, "2x" is 2 times "x".  Along these lines, this pull request tries to re-interpret simple concatenation of elements as multiplication.  There are some caveats with this:

- `2x` == `2*x`, but `xy` will be interpreted as the variable `xy` still (although `x y` == `x*y`)
- `5(1+2)` == `5*(1+2)`, but `f(1+2)` will still be interpreted as a function call (can overcome this by using brackets like `(f)(1+2)` which becomes `f*(1+2)`)