### PR TITLE
Logical refactoring and handle short-circuiting

### DIFF
--- a/lib/keisan/ast/boolean.rb
+++ b/lib/keisan/ast/boolean.rb
@@ -12,7 +12,7 @@ module Keisan
       end
 
       def true?
-        false
+        bool
       end
 
       def !

--- a/lib/keisan/ast/cell.rb
+++ b/lib/keisan/ast/cell.rb
@@ -72,6 +72,30 @@ module Keisan
       def to_node
         node
       end
+
+      def <(other)
+        other.is_a?(Cell) ? node < other.node : node < other
+      end
+
+      def <=(other)
+        other.is_a?(Cell) ? node <= other.node : node <= other
+      end
+
+      def >(other)
+        other.is_a?(Cell) ? node > other.node : node > other
+      end
+
+      def >=(other)
+        other.is_a?(Cell) ? node >= other.node : node >= other
+      end
+
+      def equal(other)
+        other.is_a?(Cell) ? node.equal(other.node) : node.equal(other)
+      end
+
+      def not_equal(other)
+        other.is_a?(Cell) ? node.not_equal(other.node) : node.not_equal(other)
+      end
     end
   end
 end

--- a/lib/keisan/ast/cell.rb
+++ b/lib/keisan/ast/cell.rb
@@ -73,28 +73,10 @@ module Keisan
         node
       end
 
-      def <(other)
-        node < other.to_node
-      end
-
-      def <=(other)
-        node <= other.to_node
-      end
-
-      def >(other)
-        node > other.to_node
-      end
-
-      def >=(other)
-        node >= other.to_node
-      end
-
-      def equal(other)
-        node.equal(other.to_node)
-      end
-
-      def not_equal(other)
-        node.not_equal(other.to_node)
+      %i(< <= > >= equal not_equal).each do |sym|
+        define_method(sym) {|other|
+          node.send(sym, other.to_node)
+        }
       end
     end
   end

--- a/lib/keisan/ast/cell.rb
+++ b/lib/keisan/ast/cell.rb
@@ -74,27 +74,27 @@ module Keisan
       end
 
       def <(other)
-        other.is_a?(Cell) ? node < other.node : node < other
+        node < other.to_node
       end
 
       def <=(other)
-        other.is_a?(Cell) ? node <= other.node : node <= other
+        node <= other.to_node
       end
 
       def >(other)
-        other.is_a?(Cell) ? node > other.node : node > other
+        node > other.to_node
       end
 
       def >=(other)
-        other.is_a?(Cell) ? node >= other.node : node >= other
+        node >= other.to_node
       end
 
       def equal(other)
-        other.is_a?(Cell) ? node.equal(other.node) : node.equal(other)
+        node.equal(other.to_node)
       end
 
       def not_equal(other)
-        other.is_a?(Cell) ? node.not_equal(other.node) : node.not_equal(other)
+        node.not_equal(other.to_node)
       end
     end
   end

--- a/lib/keisan/ast/logical_and.rb
+++ b/lib/keisan/ast/logical_and.rb
@@ -5,17 +5,34 @@ module Keisan
         :"&&"
       end
 
-      def evaluate(context = nil)
-        children[0].evaluate(context).and(children[1].evaluate(context))
-      end
-
       def blank_value
         true
+      end
+
+      def evaluate(context = nil)
+        short_circuit_do(:evaluate, context)
+      end
+
+      def simplify(context = nil)
+        short_circuit_do(:simplify, context)
       end
 
       def value(context = nil)
         context ||= Context.new
         children[0].value(context) && children[1].value(context)
+      end
+
+      private
+
+      def short_circuit_do(method, context)
+        context ||= Context.new
+        lhs = children[0].send(method, context)
+        case lhs
+        when AST::Boolean
+          lhs.false? ? AST::Boolean.new(false) : children[1].send(method, context)
+        else
+          lhs.and(children[1].send(method, context))
+        end
       end
     end
   end

--- a/lib/keisan/ast/logical_equal.rb
+++ b/lib/keisan/ast/logical_equal.rb
@@ -5,13 +5,14 @@ module Keisan
         :"=="
       end
 
-      def evaluate(context = nil)
-        children[0].evaluate(context).equal(children[1].evaluate(context))
+      protected
+
+      def value_operator
+        :==
       end
 
-      def value(context=nil)
-        context ||= Context.new
-        children[0].value(context) == children[1].value(context)
+      def operator
+        :equal
       end
     end
   end

--- a/lib/keisan/ast/logical_greater_than.rb
+++ b/lib/keisan/ast/logical_greater_than.rb
@@ -5,12 +5,14 @@ module Keisan
         :">"
       end
 
-      def evaluate(context = nil)
-        children[0].evaluate(context) > children[1].evaluate(context)
+      protected
+
+      def value_operator
+        :>
       end
 
-      def value(context = nil)
-        children.first.value(context) > children.last.value(context)
+      def operator
+        :>
       end
     end
   end

--- a/lib/keisan/ast/logical_greater_than_or_equal_to.rb
+++ b/lib/keisan/ast/logical_greater_than_or_equal_to.rb
@@ -5,12 +5,14 @@ module Keisan
         :">="
       end
 
-      def evaluate(context = nil)
-        children[0].evaluate(context) >= children[1].evaluate(context)
+      protected
+
+      def value_operator
+        :>=
       end
 
-      def value(context = nil)
-        children.first.value(context) >= children.last.value(context)
+      def operator
+        :>=
       end
     end
   end

--- a/lib/keisan/ast/logical_less_than_or_equal_to.rb
+++ b/lib/keisan/ast/logical_less_than_or_equal_to.rb
@@ -5,12 +5,14 @@ module Keisan
         :"<="
       end
 
-      def evaluate(context = nil)
-        children[0].evaluate(context) <= children[1].evaluate(context)
+      protected
+
+      def value_operator
+        :<=
       end
 
-      def value(context = nil)
-        children.first.value(context) <= children.last.value(context)
+      def operator
+        :<=
       end
     end
   end

--- a/lib/keisan/ast/logical_not_equal.rb
+++ b/lib/keisan/ast/logical_not_equal.rb
@@ -5,13 +5,14 @@ module Keisan
         :"!="
       end
 
-      def evaluate(context = nil)
-        children[0].evaluate(context).not_equal(children[1].evaluate(context))
+      protected
+
+      def value_operator
+        :!=
       end
 
-      def value(context=nil)
-        context ||= Context.new
-        children[0].value(context) != children[1].value(context)
+      def operator
+        :not_equal
       end
     end
   end

--- a/lib/keisan/ast/logical_operator.rb
+++ b/lib/keisan/ast/logical_operator.rb
@@ -1,6 +1,30 @@
 module Keisan
   module AST
     class LogicalOperator < Operator
+      def evaluate(context = nil)
+        context ||= Context.new
+        children[0].evaluate(context).send(operator, children[1].evaluate(context))
+      end
+
+      def simplify(context = nil)
+        context ||= Context.new
+        children[0].simplify(context).send(operator, children[1].simplify(context))
+      end
+
+      def value(context=nil)
+        context ||= Context.new
+        children[0].value(context).send(value_operator, children[1].value(context))
+      end
+
+      protected
+
+      def value_operator
+        raise Exceptions::NotImplementedError.new
+      end
+
+      def operator
+        raise Exceptions::NotImplementedError.new
+      end
     end
   end
 end

--- a/lib/keisan/ast/logical_or.rb
+++ b/lib/keisan/ast/logical_or.rb
@@ -10,12 +10,29 @@ module Keisan
       end
 
       def evaluate(context = nil)
-        children[0].evaluate(context).or(children[1].evaluate(context))
+        short_circuit_do(:evaluate, context)
+      end
+
+      def simplify(context = nil)
+        short_circuit_do(:simplify, context)
       end
 
       def value(context = nil)
         context ||= Context.new
         children[0].value(context) || children[1].value(context)
+      end
+
+      private
+
+      def short_circuit_do(method, context)
+        context ||= Context.new
+        lhs = children[0].send(method, context)
+        case lhs
+        when AST::Boolean
+          lhs.true? ? AST::Boolean.new(true) : children[1].send(method, context)
+        else
+          lhs.or(children[1].send(method, context))
+        end
       end
     end
   end

--- a/spec/keisan/ast/logical_spec.rb
+++ b/spec/keisan/ast/logical_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+RSpec.describe "Logical operators" do
+  let(:calculator) { Keisan::Calculator.new }
+
+  describe "evaluate" do
+    it "leaves as logical comparison when cannot fully evaluate operands" do
+      expect(Keisan::AST.parse("1 == x").evaluate).to be_a(Keisan::AST::LogicalEqual)
+    end
+
+    it "evaluates to a boolean for complex operands" do
+      calculator.evaluate("a = [1, 2, 3]")
+      calculator.evaluate("i = 1")
+      calculator.evaluate("x = 2")
+      expect(calculator.evaluate("a[i] == x")).to be true
+    end
+  end
+
+  describe "simplify" do
+    it "short-circuits if possible" do
+      expect(calculator.simplify("true || (x = 1)").value).to be true
+      expect(calculator.simplify("x")).to be_a(Keisan::AST::Variable)
+
+      expect(calculator.simplify("false && (x = 1)").value).to be false
+      expect(calculator.simplify("x")).to be_a(Keisan::AST::Variable)
+
+      expect(calculator.simplify("false || (x = 1)").value).to be 1
+      expect(calculator.simplify("x").value).to eq 1
+    end
+  end
+end

--- a/spec/keisan/ast/logical_spec.rb
+++ b/spec/keisan/ast/logical_spec.rb
@@ -1,9 +1,14 @@
 require "spec_helper"
 
-RSpec.describe "Logical operators" do
+RSpec.describe Keisan::AST::LogicalOperator do
   let(:calculator) { Keisan::Calculator.new }
 
   describe "evaluate" do
+    it "raises error on base class" do
+      expect{described_class.new(1).evaluate}.to raise_error(Keisan::Exceptions::NotImplementedError)
+      expect{described_class.new(1).value}.to raise_error(Keisan::Exceptions::NotImplementedError)
+    end
+
     it "leaves as logical comparison when cannot fully evaluate operands" do
       expect(Keisan::AST.parse("1 == x").evaluate).to be_a(Keisan::AST::LogicalEqual)
     end
@@ -13,6 +18,11 @@ RSpec.describe "Logical operators" do
       calculator.evaluate("i = 1")
       calculator.evaluate("x = 2")
       expect(calculator.evaluate("a[i] == x")).to be true
+      expect(calculator.evaluate("a[i] != x")).to be false
+      expect(calculator.evaluate("a[i] < 0")).to be false
+      expect(calculator.evaluate("a[i] <= 0")).to be false
+      expect(calculator.evaluate("a[i] > 0")).to be true
+      expect(calculator.evaluate("a[i] >= 0")).to be true
     end
   end
 

--- a/spec/keisan/functions/while_spec.rb
+++ b/spec/keisan/functions/while_spec.rb
@@ -3,8 +3,27 @@ require "spec_helper"
 RSpec.describe Keisan::Functions::While do
   it "does loops" do
     calculator = Keisan::Calculator.new
+
     calculator.evaluate("x = 0")
     calculator.evaluate("while(x < 10, x = x + 1)")
     expect(calculator.evaluate("x")).to eq 10
+
+    calculator.evaluate(<<-KEISAN
+                        includes(a, element) = {
+                          let i = 0;
+                          let found = false;
+                          while (i < a.size,
+                            if (a[i] == element,
+                              found = true;
+                              i = a.size
+                            )
+                            i += 1
+                          );
+                          found
+                        }
+    KEISAN
+                       )
+    expect(calculator.evaluate("[1,2,3].includes(2)")).to eq true
+    expect(calculator.evaluate("[1,2,3].includes(4)")).to eq false
   end
 end


### PR DESCRIPTION
Previously trying to implement an `includes` method that would loop through an array and return true if the given element is found would not work.  This PR fixes that, does some refactoring of logical operators, and ensures that `&&` and `||` operators short-circuit as appropriate.