### PR TITLE
Unbound variables works with enumerable functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ calculator.evaluate("f(0-a)", a: 2)
 #=> -20
 calculator.evaluate("n") # n only exists in the definition of f(x)
 #=> Keisan::Exceptions::UndefinedVariableError: n
+calculator.evaluate("includes(a, element) = a.reduce(false, found, x, found || (x == element))")
+calculator.evaluate("[3, 9].map(x, [1, 3, 5].includes(x))").value
+#=> [true, false]
 ```
 
 This form even supports recursion, but you must explicitly allow it.

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ calculator.evaluate("log10(1000)")
 #=> 3.0
 ```
 
-Furthermore, the constants `PI`, `E`, and `I` are included.
+Furthermore, the constants `PI`, `E`, `I`, and `INF` are included.
 
 ```ruby
 calculator = Keisan::Calculator.new

--- a/lib/keisan/ast/function.rb
+++ b/lib/keisan/ast/function.rb
@@ -13,6 +13,15 @@ module Keisan
         function_from_context(context).value(self, context)
       end
 
+      def unbound_variables(context = nil)
+        context ||= Context.new
+        if context.has_function?(name)
+          function_from_context(context).unbound_variables(children, context)
+        else
+          super
+        end
+      end
+
       def unbound_functions(context = nil)
         context ||= Context.new
 

--- a/lib/keisan/ast/logical_less_than.rb
+++ b/lib/keisan/ast/logical_less_than.rb
@@ -5,12 +5,14 @@ module Keisan
         :"<"
       end
 
-      def evaluate(context = nil)
-        children[0].evaluate(context) < children[1].evaluate(context)
+      protected
+
+      def value_operator
+        :<
       end
 
-      def value(context = nil)
-        children.first.value(context) < children.last.value(context)
+      def operator
+        :<
       end
     end
   end

--- a/lib/keisan/function.rb
+++ b/lib/keisan/function.rb
@@ -23,6 +23,12 @@ module Keisan
       raise Exceptions::NotImplementedError.new
     end
 
+    def unbound_variables(children, context)
+      children.inject(Set.new) do |vars, child|
+        vars | child.unbound_variables(context)
+      end
+    end
+
     protected
 
     def validate_arguments!(count)

--- a/lib/keisan/functions/enumerable_function.rb
+++ b/lib/keisan/functions/enumerable_function.rb
@@ -12,6 +12,10 @@ module Keisan
         evaluate(ast_function, context)
       end
 
+      def unbound_variables(children, context)
+        super - Set.new(shadowing_variable_names(children).map(&:name))
+      end
+
       def evaluate(ast_function, context = nil)
         validate_arguments!(ast_function.children.count)
         context ||= Context.new
@@ -20,9 +24,9 @@ module Keisan
 
         case operand
         when AST::List
-          evaluate_list(operand, arguments, expression, context)
+          evaluate_list(operand, arguments, expression, context).evaluate(context)
         when AST::Hash
-          evaluate_hash(operand, arguments, expression, context)
+          evaluate_hash(operand, arguments, expression, context).evaluate(context)
         else
           raise Exceptions::InvalidFunctionError.new("Unhandled first argument to #{name}: #{operand}")
         end
@@ -33,6 +37,10 @@ module Keisan
       end
 
       protected
+
+      def shadowing_variable_names(children)
+        raise Exceptions::NotImplementedError.new
+      end
 
       def verify_arguments!(arguments)
         unless arguments.all? {|argument| argument.is_a?(AST::Variable)}

--- a/lib/keisan/functions/filter.rb
+++ b/lib/keisan/functions/filter.rb
@@ -10,6 +10,14 @@ module Keisan
         super("filter")
       end
 
+      def unbound_variables(children, context)
+        if children.size == 3
+          super - Set[children[1].name]
+        else
+          super - Set[children[1].name, children[2].name]
+        end
+      end
+
       private
 
       def evaluate_list(list, arguments, expression, context)

--- a/lib/keisan/functions/filter.rb
+++ b/lib/keisan/functions/filter.rb
@@ -10,12 +10,10 @@ module Keisan
         super("filter")
       end
 
-      def unbound_variables(children, context)
-        if children.size == 3
-          super - Set[children[1].name]
-        else
-          super - Set[children[1].name, children[2].name]
-        end
+      protected
+
+      def shadowing_variable_names(children)
+        children.size == 3 ? children[1..1] : children[1..2]
       end
 
       private

--- a/lib/keisan/functions/map.rb
+++ b/lib/keisan/functions/map.rb
@@ -10,12 +10,10 @@ module Keisan
         super("map")
       end
 
-      def unbound_variables(children, context)
-        if children.size == 3
-          super - Set[children[1].name]
-        else
-          super - Set[children[1].name, children[2].name]
-        end
+      protected
+
+      def shadowing_variable_names(children)
+        children.size == 3 ? children[1..1] : children[1..2]
       end
 
       private

--- a/lib/keisan/functions/map.rb
+++ b/lib/keisan/functions/map.rb
@@ -10,6 +10,14 @@ module Keisan
         super("map")
       end
 
+      def unbound_variables(children, context)
+        if children.size == 3
+          super - Set[children[1].name]
+        else
+          super - Set[children[1].name, children[2].name]
+        end
+      end
+
       private
 
       def evaluate_list(list, arguments, expression, context)

--- a/lib/keisan/functions/reduce.rb
+++ b/lib/keisan/functions/reduce.rb
@@ -6,8 +6,17 @@ module Keisan
       # Reduces (list, initial, accumulator, variable, expression)
       # e.g. reduce([1,2,3,4], 0, total, x, total+x)
       # should give 10
+      # When hash: (hash, initial, accumulator, key, value, expression)
       def initialize
         super("reduce")
+      end
+
+      def unbound_variables(children, context)
+        if children.size == 5
+          super - Set[children[2].name, children[3].name]
+        else
+          super - Set[children[2].name, children[3].name, children[4].name]
+        end
       end
 
       protected

--- a/lib/keisan/functions/reduce.rb
+++ b/lib/keisan/functions/reduce.rb
@@ -11,15 +11,11 @@ module Keisan
         super("reduce")
       end
 
-      def unbound_variables(children, context)
-        if children.size == 5
-          super - Set[children[2].name, children[3].name]
-        else
-          super - Set[children[2].name, children[3].name, children[4].name]
-        end
-      end
-
       protected
+
+      def shadowing_variable_names(children)
+        children.size == 5 ? children[2..3] : children[2..4]
+      end
 
       def verify_arguments!(arguments)
         unless arguments[1..-1].all? {|argument| argument.is_a?(AST::Variable)}

--- a/lib/keisan/variables/default_registry.rb
+++ b/lib/keisan/variables/default_registry.rb
@@ -4,7 +4,8 @@ module Keisan
       VARIABLES = {
         "PI" => Math::PI,
         "E" => Math::E,
-        "I" => Complex(0,1)
+        "I" => Complex(0,1),
+        "INF" => Float::INFINITY
       }
 
       def self.registry

--- a/spec/keisan/ast/function_assignment_spec.rb
+++ b/spec/keisan/ast/function_assignment_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe Keisan::AST::FunctionAssignment do
+  describe "unbound_variables" do
+    it "shadows the appropriate enumerable method variables" do
+      ast = Keisan::AST.parse("double(a) = a.map(x, 2*x)")
+      expect(ast.unbound_variables).to eq Set["a"]
+
+      ast = Keisan::AST.parse("triple(h) = h.map(k, v, [k, 3*v])")
+      expect(ast.unbound_variables).to eq Set["h"]
+
+      ast = Keisan::AST.parse("even(a) = a.filter(x, x % 2 == 0)")
+      expect(ast.unbound_variables).to eq Set["a"]
+
+      ast = Keisan::AST.parse("odd(h) = h.filter(k, v, v % 2 == 1)")
+      expect(ast.unbound_variables).to eq Set["h"]
+
+      ast = Keisan::AST.parse("include(a,x) = a.reduce(false, found, y, found || (x == y))")
+      expect(ast.unbound_variables).to eq Set["a", "x"]
+
+      ast = Keisan::AST.parse("include(h,x) = h.reduce(false, found, k, v, found || (v == x))")
+      expect(ast.unbound_variables).to eq Set["h", "x"]
+    end
+  end
+end

--- a/spec/keisan/ast/function_assignment_spec.rb
+++ b/spec/keisan/ast/function_assignment_spec.rb
@@ -22,4 +22,10 @@ RSpec.describe Keisan::AST::FunctionAssignment do
       expect(ast.unbound_variables).to eq Set["h", "x"]
     end
   end
+
+  it "works with complex reduce expression" do
+    calculator = Keisan::Calculator.new
+    calculator.evaluate("minimum(a) = a.reduce(INF, current_min, element, if (element < current_min, element, current_min))")
+    expect(calculator.evaluate("minimum([5,1,3])")).to eq 1
+  end
 end

--- a/spec/keisan/ast/function_assignment_spec.rb
+++ b/spec/keisan/ast/function_assignment_spec.rb
@@ -27,5 +27,8 @@ RSpec.describe Keisan::AST::FunctionAssignment do
     calculator = Keisan::Calculator.new
     calculator.evaluate("minimum(a) = a.reduce(INF, current_min, element, if (element < current_min, element, current_min))")
     expect(calculator.evaluate("minimum([5,1,3])")).to eq 1
+
+    calculator.evaluate("includes(a, element) = a.reduce(false, found, x, found || (x == element))")
+    expect(calculator.evaluate("[3, 9].map(x, [1, 3, 5].includes(x))")).to eq([true, false])
   end
 end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "README.md" do
       digest = Digest::SHA256.hexdigest(content)
 
       # cat README.md | sha256sum
-      expected_digest = "2b80635dad47bcbaf98d081e0a041ed5357377d89fb272e2081052e1b1b4e605"
+      expected_digest = "399be39e65ec8aaace1f9ce266415bf49627572bcd2ee6f8e05d9f4a62cc241c"
       if digest != expected_digest
         raise "Invalid README file detected with SHA256 digest of #{digest}. Use command `cat README.md | sha256sum` to get correct digest if your changes to the README are safe. Aborting README test."
       end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "README.md" do
       digest = Digest::SHA256.hexdigest(content)
 
       # cat README.md | sha256sum
-      expected_digest = "399be39e65ec8aaace1f9ce266415bf49627572bcd2ee6f8e05d9f4a62cc241c"
+      expected_digest = "c430ca4bd926e553e7414c96f89b8f81ef8bf3c491c5484e9f9599f38e06e2f7"
       if digest != expected_digest
         raise "Invalid README file detected with SHA256 digest of #{digest}. Use command `cat README.md | sha256sum` to get correct digest if your changes to the README are safe. Aborting README test."
       end


### PR DESCRIPTION
Previously a function assignment like `"double(a) = a.map(x, 2*x)"` would fail without curly braces because `x` was undefined.  However the `x` argument to `map` is _supposed_ to be an unbound variable, so this PR updates the code to handle correctly this problem and make such an assignment possible.  See the spec changes for examples of such now allowable assignments.