### PR TITLE
Differentiation should work with user defined functions

### DIFF
--- a/lib/keisan/ast/node.rb
+++ b/lib/keisan/ast/node.rb
@@ -45,8 +45,16 @@ module Keisan
         raise Exceptions::NonDifferentiableError.new
       end
 
+      def differentiated(variable, context = nil)
+        deep_dup.differentiate(variable, context)
+      end
+
       def replace(variable, replacement)
         self
+      end
+
+      def replaced(variable, replacement)
+        deep_dup.replace(variable, replacement)
       end
 
       def coerce(other)

--- a/lib/keisan/ast/unary_inverse.rb
+++ b/lib/keisan/ast/unary_inverse.rb
@@ -19,7 +19,7 @@ module Keisan
         @children = [child.simplify(context)]
         case child
         when Number
-          Number.new(Rational(1,child.value(context))).simplify(context)
+          Number.new(child.value**-1)
         else
           (child ** -1).simplify(context)
         end

--- a/lib/keisan/ast/variable.rb
+++ b/lib/keisan/ast/variable.rb
@@ -13,7 +13,13 @@ module Keisan
 
       def value(context = nil)
         context ||= Context.new
-        variable_node_from_context(context).value(context)
+        node = variable_node_from_context(context)
+        case node
+        when Variable
+          node
+        else
+          node.value(context)
+        end
       end
 
       def unbound_variables(context = nil)
@@ -78,9 +84,7 @@ module Keisan
 
       def variable_node_from_context(context)
         variable = context.variable(name)
-        if variable.is_a?(Cell)
-          variable = variable.node
-        end
+        variable = variable.node if variable.is_a?(Cell)
         variable
       end
     end

--- a/lib/keisan/functions/cmath_function.rb
+++ b/lib/keisan/functions/cmath_function.rb
@@ -4,7 +4,9 @@ module Keisan
   module Functions
     class CMathFunction < MathFunction
       def initialize(name, proc_function = nil)
-        super(name, proc_function || Proc.new {|arg| CMath.send(name, arg)})
+        super(name, proc_function || Proc.new {|arg|
+          CMath.send(name, arg)
+        })
       end
     end
   end

--- a/lib/keisan/functions/proc_function.rb
+++ b/lib/keisan/functions/proc_function.rb
@@ -28,7 +28,7 @@ module Keisan
 
         ast_function.instance_variable_set(
           :@children,
-          ast_function.children.map {|child| child.evaluate(context).to_node}
+          ast_function.children.map {|child| child.simplify(context).to_node}
         )
 
         if ast_function.children.all? {|child| child.well_defined?(context)}
@@ -44,7 +44,7 @@ module Keisan
 
         ast_function.instance_variable_set(
           :@children,
-          ast_function.children.map {|child| child.evaluate(context)}
+          ast_function.children.map {|child| child.simplify(context)}
         )
 
         if ast_function.children.all? {|child| child.is_a?(AST::ConstantLiteral)}

--- a/lib/keisan/functions/replace.rb
+++ b/lib/keisan/functions/replace.rb
@@ -10,19 +10,19 @@ module Keisan
         evaluate(ast_function, context).value(context)
       end
 
-      def evaluate(ast_function, context = nil)
+      def simplify(ast_function, context = nil)
         context ||= Context.new
         expression, variable, replacement = expression_variable_replacement(ast_function)
 
-        expression = expression.evaluate(context)
-        replacement = replacement.evaluate(context)
+        expression = expression.simplify(context)
+        replacement = replacement.simplify(context)
 
-        expression.replace(variable, replacement).evaluate(context)
+        expression.replace(variable, replacement).simplify(context)
       end
 
-      def simplify(ast_function, context = nil)
+      def evaluate(ast_function, context = nil)
         context ||= Context.new
-        evaluate(ast_function, context).simplify(context)
+        simplify(ast_function, context).evaluate(context)
       end
 
       private

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -136,6 +136,19 @@ RSpec.describe Keisan::Calculator do
       expect{calculator.evaluate("0*x+1")}.to raise_error(Keisan::Exceptions::UndefinedVariableError)
       expect(calculator.simplify("0*x+1").to_s).to eq "1"
     end
+
+    it "simplifies inside functions" do
+      ast = calculator.simplify("exp((a**2)*(1*(1*(1*(1*(1*(1*((b)**(-1)))))))))")
+      expect(ast).to be_a(Keisan::AST::Function)
+      expect(ast.name).to eq "exp"
+      expect(ast.children.size).to eq 1
+      expect(ast.children[0]).to be_a(Keisan::AST::Times)
+
+      expect(ast.children[0].children.size).to eq 2
+      expect(ast.children[0].children.map(&:to_s)).to eq([
+        "a**2", "b**-1"
+      ])
+    end
   end
 
   describe "#ast" do

--- a/spec/keisan/differentiation_spec.rb
+++ b/spec/keisan/differentiation_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+RSpec.describe "Differentiation" do
+  let(:calculator) { Keisan::Calculator.new }
+
+  describe "diff of expression functions" do
+    context "single variable" do
+      it "can be used to assign variables" do
+        calculator.evaluate("my_func(x) = x*log(x)")
+        expect(calculator.evaluate("my_func(10)")).to eq(10 * Math::log(10))
+        expect(calculator.evaluate("replace(diff(my_func(x), x), x, 10)")).to eq(1 + Math::log(10))
+      end
+    end
+
+    context "two variables" do
+      it "can be used to assign variables" do
+        calculator.evaluate("my_func(x, y) = x*exp(x*y)")
+        expect(calculator.evaluate("my_func(3, 5)")).to eq(3*Math::exp(15))
+
+        expect(calculator.evaluate("replace(replace(diff(my_func(a, b), a), a, 2), b, 3)")).to eq(
+          (2*3 + 1)*Math::exp(2*3)
+        )
+
+        expect(calculator.evaluate("replace(replace(diff(my_func(a**2, 1/b), a), a, 2), b, 1.5)")).to eq(
+          2*2*(1 + 2**2/1.5) * Math::exp(2**2 / 1.5)
+        )
+      end
+    end
+
+    context "differentiation variable is an already defined variable" do
+      it "does not interfere with differentiation" do
+        calculator.evaluate("x = 5")
+        calculator.evaluate("f(x) = x**2")
+        expect(calculator.evaluate("f(10)")).to eq 100
+        expect(calculator.evaluate("diff(f(x), x)")).to eq 10
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously it was not possible to calculate the derivatives of a user defined function, like `"f(x) = x*log(x); diff(f(x), x)"`, even though one could calculate the derivative directly, `"diff(x*log(x), x)"`.  This pull request remedies this problem.