### PR TITLE
Fix brace matching problem inside strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: ruby
+before_install:
+  - gem install bundler
 rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
-before_install: gem install bundler -v 1.17.1
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
+  - 2.7.0

--- a/keisan.gemspec
+++ b/keisan.gemspec
@@ -21,10 +21,12 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_development_dependency "coveralls"
-  spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_dependency "cmath", "~> 1.0"
+
+  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-stack_explorer"
+  spec.add_development_dependency "simplecov"
 end

--- a/lib/keisan.rb
+++ b/lib/keisan.rb
@@ -85,6 +85,7 @@ require "keisan/tokens/word"
 require "keisan/tokens/line_separator"
 require "keisan/tokens/unknown"
 
+require "keisan/string_and_group_parser"
 require "keisan/tokenizer"
 
 require "keisan/parsing/component"

--- a/lib/keisan/string_and_group_parser.rb
+++ b/lib/keisan/string_and_group_parser.rb
@@ -1,0 +1,195 @@
+module Keisan
+  class StringAndGroupParser
+    class Portion
+      attr_reader :expression, :start_index, :end_index
+
+      def initialize(expression, start_index)
+        @expression = expression
+        @start_index = start_index
+      end
+    end
+
+    class StringPortion < Portion
+      attr_reader :string
+
+      def initialize(expression, start_index)
+        super
+
+        @string = expression[start_index]
+        index = start_index + 1
+
+        while index < expression.size
+          c = expression[index]
+          if c == quote_type
+            @string << c
+            index += 1
+            break
+          end
+
+          # escape character
+          if c == "\\"
+            index += 1
+            if index >= expression.size
+              raise Keisan::Exceptions::TokenizingError.new("Tokenizing error, no closing quote #{quote_type}")
+            end
+            c = expression[index]
+
+            case c
+            when "\\", '"', "'"
+              @string << c
+            when "a"
+              @string << "\a"
+            when "b"
+              @string << "\b"
+            when "r"
+              @string << "\r"
+            when "n"
+              @string << "\n"
+            when "s"
+              @string << "\s"
+            when "t"
+              @string << "\t"
+            else
+              raise Keisan::Exceptions::TokenizingError.new("Tokenizing error, unknown escape character: \\#{c}")
+            end
+          else
+            @string << c
+          end
+
+          index += 1
+        end
+
+        @end_index = index
+
+        if @string.size <= 1 || @string[-1] != @string[0]
+          raise Keisan::Exceptions::TokenizingError.new("Tokenizing error, no closing quote #{quote_type}")
+        end
+      end
+
+      def quote_type
+        @string[0]
+      end
+
+      def size
+        string.size
+      end
+
+      def to_s
+        string
+      end
+    end
+
+    class GroupPortion < Portion
+      attr_reader :opening_brace, :closing_brace ,:portions, :size
+
+      def initialize(expression, start_index)
+        super
+
+        case expression[start_index]
+        when OPEN_GROUP_REGEX
+          @opening_brace = expression[start_index]
+
+        else
+          raise Keisan::Exceptions::TokenizingError.new("Internal error, GroupPortion did not start with brace")
+        end
+
+        case opening_brace
+        when "("
+          @closing_brace = ")"
+        when "{"
+          @closing_brace = "}"
+        when "["
+          @closing_brace = "]"
+        end
+
+        parser = StringAndGroupParser.new(expression, start_index: start_index + 1, ending_character: closing_brace)
+        @portions = parser.portions
+        @size = parser.size + 2
+
+        if start_index + size > expression.size || expression[start_index + size - 1] != closing_brace
+          raise Keisan::Exceptions::TokenizingError.new("Tokenizing error, group with opening brace #{opening_brace} did not have closing brace")
+        end
+      end
+
+      def to_s
+        opening_brace + portions.map(&:to_s).join + closing_brace
+      end
+    end
+
+    class OtherPortion < Portion
+      attr_reader :string
+
+      def initialize(expression, start_index)
+        super
+
+        case expression[start_index]
+        when STRING_CHARACTER_REGEX, OPEN_GROUP_REGEX, CLOSED_GROUP_REGEX
+          raise Keisan::Exceptions::TokenizingError.new("Internal error, OtherPortion should not have string/braces at start")
+        else
+          index = start_index + 1
+        end
+
+        while index < expression.size
+          case expression[index]
+          when STRING_CHARACTER_REGEX, OPEN_GROUP_REGEX, CLOSED_GROUP_REGEX
+            break
+          else
+            index += 1
+          end
+        end
+
+        @end_index = index
+        @string = expression[start_index...end_index]
+      end
+
+      def size
+        string.size
+      end
+
+      def to_s
+        string
+      end
+    end
+
+    # An ordered array of "portions", which
+    attr_reader :portions, :size
+
+    STRING_CHARACTER_REGEX = /["']/
+    OPEN_GROUP_REGEX = /[\(\{\[]/
+    CLOSED_GROUP_REGEX = /[\)\}\]]/
+
+    # Ending character is used as a second ending condition besides expression size
+    def initialize(expression, start_index: 0, ending_character: nil)
+      index = start_index
+      @portions = []
+
+      while index < expression.size && (ending_character.nil? || expression[index] != ending_character)
+        case expression[index]
+        when STRING_CHARACTER_REGEX
+          portion = StringPortion.new(expression, index)
+          index = portion.end_index
+          @portions << portion
+
+        when OPEN_GROUP_REGEX
+          portion = GroupPortion.new(expression, index)
+          index += portion.size
+          @portions << portion
+
+        when CLOSED_GROUP_REGEX
+          raise Keisan::Exceptions::TokenizingError.new("Tokenizing error, unexpected closing brace #{expression[start_index]}")
+
+        else
+          portion = OtherPortion.new(expression, index)
+          index += portion.size
+          @portions << portion
+        end
+      end
+
+      @size = index - start_index
+    end
+
+    def to_s
+      portions.map(&:to_s).join
+    end
+  end
+end

--- a/lib/keisan/tokenizer.rb
+++ b/lib/keisan/tokenizer.rb
@@ -1,8 +1,6 @@
 module Keisan
   class Tokenizer
     TOKEN_CLASSES = [
-      Tokens::Group,
-      Tokens::String,
       Tokens::Null,
       Tokens::Boolean,
       Tokens::Word,
@@ -27,8 +25,20 @@ module Keisan
 
     def initialize(expression)
       @expression = self.class.normalize_expression(expression)
-      @scan = @expression.scan(TOKEN_REGEX)
-      @tokens = tokenize!
+      intermediate_tokens = parse_strings_and_groups
+      @tokens = intermediate_tokens.map do |sym, string|
+        case sym
+        when :string
+          Tokens::String.new(string)
+        when :group
+          Tokens::Group.new(string)
+        when :other
+          scan = string.scan(TOKEN_REGEX)
+          tokenize!(scan)
+        else
+          raise Keisan::Exceptions::TokenizingError.new("Internal error, unexpected symbol: #{sym}")
+        end
+      end.flatten
     end
 
     def self.normalize_expression(expression)
@@ -38,6 +48,118 @@ module Keisan
 
     private
 
+    def parse_strings_and_groups
+      braces = []
+      braces_start = nil
+
+      tokens = []
+
+      current_other = nil
+      current_string = nil
+
+      i = 0
+      while i < @expression.size
+        c = @expression[i]
+
+        if !braces.empty?
+          if current_string
+            # Escape character
+            if c == "\\"
+              i += 1
+              c = @expression[i]
+            # Exit string
+            elsif c == current_string[0]
+              current_string = nil
+            end
+
+          # Not in string
+          else
+            case c
+            # New string
+            when '"', "'"
+              current_string = c
+            # New opening brace
+            when "(", "[", "{"
+              braces << c
+            # Closing brace
+            when ")"
+              if braces[-1] != "("
+                raise Keisan::Exceptions::TokenizingError.new("Expected closing brace ')', found '#{c}'")
+              end
+              braces.pop
+            when "]"
+              if braces[-1] != "["
+                raise Keisan::Exceptions::TokenizingError.new("Expected closing brace ']', found '#{c}'")
+              end
+              braces.pop
+            when "}"
+              if braces[-1] != "{"
+                raise Keisan::Exceptions::TokenizingError.new("Expected closing brace '}', found '#{c}'")
+              end
+              braces.pop
+            end
+          end
+
+          if braces.empty?
+            tokens << [:group, @expression[braces_start..i]]
+          end
+        elsif current_string
+          # Escape character
+          if c == "\\"
+            i += 1
+            c = @expression[i]
+            current_string << c
+          else
+            current_string << c
+            # Exit string
+            if c == current_string[0]
+              tokens << [:string, current_string]
+              current_string = nil
+            end
+          end
+        else
+          case c
+          # New string
+          when '"', "'"
+            if current_other
+              tokens << [:other, current_other]
+              current_other = nil
+            end
+
+            current_string = c
+          # New opening brace
+          when "(", "[", "{"
+            if current_other
+              tokens << [:other, current_other]
+              current_other = nil
+            end
+
+            braces = [c]
+            braces_start = i
+          # Closing brace
+          when ")", "]", "}"
+            raise Keisan::Exceptions::TokenizingError.new("Found unmatched closing braced '#{c}'")
+          else
+            current_other ||= ""
+            current_other << c
+          end
+        end
+
+        i += 1
+      end
+
+      if current_other
+        tokens << [:other, current_other]
+        current_other = nil
+      end
+
+      if !braces.empty?
+        raise Keisan::Exceptions::TokenizingError.new("Found unmatched closing brace '#{braces[0]}'")
+      end
+
+      return tokens
+    end
+
     def self.normalize_line_delimiters(expression)
       expression.gsub(/\n/, ";")
     end
@@ -46,11 +168,12 @@ module Keisan
       expression.gsub(/#[^;]*/, "")
     end
 
-    def tokenize!
-      @scan.map do |scan_result|
+    def tokenize!(scan)
+      scan.map do |scan_result|
         i = scan_result.find_index {|token| !token.nil?}
         token_string = scan_result[i]
         token = TOKEN_CLASSES[i].new(token_string)
+        # binding.pry
         if token.is_a?(Tokens::Unknown)
           raise Keisan::Exceptions::TokenizingError.new("Unexpected token: \"#{token.string}\"")
         end

--- a/lib/keisan/tokenizer.rb
+++ b/lib/keisan/tokenizer.rb
@@ -25,20 +25,22 @@ module Keisan
 
     def initialize(expression)
       @expression = self.class.normalize_expression(expression)
-      intermediate_tokens = parse_strings_and_groups
-      @tokens = intermediate_tokens.map do |sym, string|
-        case sym
-        when :string
-          Tokens::String.new(string)
-        when :group
-          Tokens::Group.new(string)
-        when :other
-          scan = string.scan(TOKEN_REGEX)
-          tokenize!(scan)
-        else
-          raise Keisan::Exceptions::TokenizingError.new("Internal error, unexpected symbol: #{sym}")
+
+      portions = StringAndGroupParser.new(@expression).portions
+
+      @tokens = portions.inject([]) do |tokens, portion|
+        case portion
+        when StringAndGroupParser::StringPortion
+          tokens << Tokens::String.new(portion.to_s)
+        when StringAndGroupParser::GroupPortion
+          tokens << Tokens::Group.new(portion.to_s)
+        when StringAndGroupParser::OtherPortion
+          scan = portion.to_s.scan(TOKEN_REGEX)
+          tokens += tokenize!(scan)
         end
-      end.flatten
+
+        tokens
+      end
     end
 
     def self.normalize_expression(expression)
@@ -47,118 +49,6 @@ module Keisan
     end
 
     private
-
-    def parse_strings_and_groups
-      braces = []
-      braces_start = nil
-
-      tokens = []
-
-      current_other = nil
-      current_string = nil
-
-      i = 0
-      while i < @expression.size
-        c = @expression[i]
-
-        if !braces.empty?
-          if current_string
-            # Escape character
-            if c == "\\"
-              i += 1
-              c = @expression[i]
-            # Exit string
-            elsif c == current_string[0]
-              current_string = nil
-            end
-
-          # Not in string
-          else
-            case c
-            # New string
-            when '"', "'"
-              current_string = c
-            # New opening brace
-            when "(", "[", "{"
-              braces << c
-            # Closing brace
-            when ")"
-              if braces[-1] != "("
-                raise Keisan::Exceptions::TokenizingError.new("Expected closing brace ')', found '#{c}'")
-              end
-              braces.pop
-            when "]"
-              if braces[-1] != "["
-                raise Keisan::Exceptions::TokenizingError.new("Expected closing brace ']', found '#{c}'")
-              end
-              braces.pop
-            when "}"
-              if braces[-1] != "{"
-                raise Keisan::Exceptions::TokenizingError.new("Expected closing brace '}', found '#{c}'")
-              end
-              braces.pop
-            end
-          end
-
-          if braces.empty?
-            tokens << [:group, @expression[braces_start..i]]
-          end
-        elsif current_string
-          # Escape character
-          if c == "\\"
-            i += 1
-            c = @expression[i]
-            current_string << c
-          else
-            current_string << c
-            # Exit string
-            if c == current_string[0]
-              tokens << [:string, current_string]
-              current_string = nil
-            end
-          end
-        else
-          case c
-          # New string
-          when '"', "'"
-            if current_other
-              tokens << [:other, current_other]
-              current_other = nil
-            end
-
-            current_string = c
-          # New opening brace
-          when "(", "[", "{"
-            if current_other
-              tokens << [:other, current_other]
-              current_other = nil
-            end
-
-            braces = [c]
-            braces_start = i
-          # Closing brace
-          when ")", "]", "}"
-            raise Keisan::Exceptions::TokenizingError.new("Found unmatched closing braced '#{c}'")
-          else
-            current_other ||= ""
-            current_other << c
-          end
-        end
-
-        i += 1
-      end
-
-      if current_other
-        tokens << [:other, current_other]
-        current_other = nil
-      end
-
-      if !braces.empty?
-        raise Keisan::Exceptions::TokenizingError.new("Found unmatched closing brace '#{braces[0]}'")
-      end
-
-      return tokens
-    end
 
     def self.normalize_line_delimiters(expression)
       expression.gsub(/\n/, ";")
@@ -173,7 +63,6 @@ module Keisan
         i = scan_result.find_index {|token| !token.nil?}
         token_string = scan_result[i]
         token = TOKEN_CLASSES[i].new(token_string)
-        # binding.pry
         if token.is_a?(Tokens::Unknown)
           raise Keisan::Exceptions::TokenizingError.new("Unexpected token: \"#{token.string}\"")
         end

--- a/lib/keisan/tokens/group.rb
+++ b/lib/keisan/tokens/group.rb
@@ -1,12 +1,13 @@
 module Keisan
   module Tokens
     class Group < Token
-      REGEX = /(\((?:[^\[\]\(\)\{\}]*+\g<1>*+)*+\)|\[(?:[^\[\]\(\)\{\}]*+\g<1>*+)*+\]|\{(?:[^\[\]\(\)\{\}]*+\g<1>*+)*+\})/
+      REGEX = /(\(|\)|\[|\]|\{|\})/
 
       attr_reader :sub_tokens
 
       def initialize(string)
-        super
+        @string = string
+        raise Exceptions::InvalidToken.new(string) unless string[0].match(regex) && string[-1].match(regex)
         @sub_tokens = Tokenizer.new(string[1...-1]).tokens
       end
 

--- a/lib/keisan/tokens/group.rb
+++ b/lib/keisan/tokens/group.rb
@@ -1,18 +1,11 @@
 module Keisan
   module Tokens
     class Group < Token
-      REGEX = /(\(|\)|\[|\]|\{|\})/
-
       attr_reader :sub_tokens
 
       def initialize(string)
         @string = string
-        raise Exceptions::InvalidToken.new(string) unless string[0].match(regex) && string[-1].match(regex)
         @sub_tokens = Tokenizer.new(string[1...-1]).tokens
-      end
-
-      def self.regex
-        REGEX
       end
 
       # Either :round, :square

--- a/lib/keisan/tokens/string.rb
+++ b/lib/keisan/tokens/string.rb
@@ -1,10 +1,8 @@
 module Keisan
   module Tokens
     class String < Token
-      REGEX = /(\"[^\"]*\"|\'[^\']*\')/
-
-      def self.regex
-        REGEX
+      def initialize(string)
+        @string = string
       end
 
       def value

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -131,6 +131,12 @@ RSpec.describe Keisan::Calculator do
     end
   end
 
+  describe "unmatched braces inside strings" do
+    it "does not match against actual braces outside strings" do
+      expect(calculator.evaluate("'1'+'2'+(']\\]') + (('3') + '4')")).to eq "12]]34"
+    end
+  end
+
   describe "#simplify" do
     it "allows for undefined variables to still exist and returns a string representation of the expression" do
       expect{calculator.evaluate("0*x+1")}.to raise_error(Keisan::Exceptions::UndefinedVariableError)

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Keisan::Calculator do
 
   describe "unmatched braces inside strings" do
     it "does not match against actual braces outside strings" do
-      expect(calculator.evaluate("'1'+'2'+(']\\]') + (('3') + '4')")).to eq "12]]34"
+      expect(calculator.evaluate("'1'+'2'+(']\n]') + (('3') + '4')")).to eq "12];]34"
     end
   end
 

--- a/spec/keisan/string_and_group_parser_spec.rb
+++ b/spec/keisan/string_and_group_parser_spec.rb
@@ -1,0 +1,108 @@
+require "spec_helper"
+
+RSpec.describe Keisan::StringAndGroupParser do
+  describe described_class::OtherPortion do
+    it "cannot start with a quote or brace character" do
+      expect { described_class.new("''", 0) }.to raise_error Keisan::Exceptions::TokenizingError
+      expect { described_class.new("(", 0) }.to raise_error Keisan::Exceptions::TokenizingError
+      expect { described_class.new(")", 0) }.to raise_error Keisan::Exceptions::TokenizingError
+    end
+
+    it "consumes characters up to a quote or opening brace character" do
+      parser = described_class.new("1 + ''", 0)
+      expect(parser.end_index).to eq 4
+      expect(parser.string).to eq ("1 + ")
+
+      parser = described_class.new("1 + ()", 0)
+      expect(parser.end_index).to eq 4
+      expect(parser.string).to eq ("1 + ")
+
+      parser = described_class.new("'' + 1", 2)
+      expect(parser.end_index).to eq 6
+      expect(parser.string).to eq (" + 1")
+    end
+  end
+
+  describe described_class::StringPortion do
+    it "works on strings at different positions" do
+      parser = described_class.new("''", 0)
+      expect(parser.start_index).to eq 0
+      expect(parser.end_index).to eq 2
+      expect(parser.string).to eq "''"
+
+      parser = described_class.new("'hello'", 0)
+      expect(parser.start_index).to eq 0
+      expect(parser.end_index).to eq 7
+      expect(parser.string).to eq "'hello'"
+
+      parser = described_class.new("'hello' + 1", 0)
+      expect(parser.start_index).to eq 0
+      expect(parser.end_index).to eq 7
+      expect(parser.string).to eq "'hello'"
+
+      parser = described_class.new("1 + 'hello'", 4)
+      expect(parser.start_index).to eq 4
+      expect(parser.end_index).to eq 11
+      expect(parser.string).to eq "'hello'"
+
+      parser = described_class.new("1 + 'hello' + 2", 4)
+      expect(parser.start_index).to eq 4
+      expect(parser.end_index).to eq 11
+      expect(parser.string).to eq "'hello'"
+    end
+
+    it "handles escape characters" do
+      parser = described_class.new("1 + 'a\\\\b' + 2", 4)
+      expect(parser.start_index).to eq 4
+      expect(parser.end_index).to eq 10
+      expect(parser.string).to eq "'a\\b'"
+    end
+
+    it "can have braces" do
+      parser = described_class.new("1 + \"a()b\" + 2", 4)
+      expect(parser.start_index).to eq 4
+      expect(parser.end_index).to eq 10
+      expect(parser.string).to eq '"a()b"'
+    end
+
+    it "fails on incorrect start_index" do
+      expect { described_class.new("1 + \"hello\"", 0) }.to raise_error Keisan::Exceptions::TokenizingError
+    end
+
+    it "fails when no closing quote found" do
+      expect { described_class.new("\"hello'", 0) }.to raise_error Keisan::Exceptions::TokenizingError
+    end
+
+    it "fails on unknown escape character" do
+      expect { described_class.new("'as\\cdf'", 0) }.to raise_error Keisan::Exceptions::TokenizingError
+    end
+  end
+
+  describe described_class::GroupPortion do
+    it "must start and end with opening and closing braces" do
+      expect { described_class.new("x", 0) }.to raise_error Keisan::Exceptions::TokenizingError
+      expect { described_class.new("1", 0) }.to raise_error Keisan::Exceptions::TokenizingError
+      expect { described_class.new("''", 0) }.to raise_error Keisan::Exceptions::TokenizingError
+      expect { described_class.new("(", 0) }.to raise_error Keisan::Exceptions::TokenizingError
+      expect { described_class.new("(]", 0) }.to raise_error Keisan::Exceptions::TokenizingError
+    end
+
+    it "parses the internal portions inside the braces" do
+      parser = described_class.new("()", 0)
+      expect(parser.portions).to match_array([])
+
+      parser = described_class.new("(1 + '2' + [3])", 0)
+      expect(parser.opening_brace).to eq "("
+      expect(parser.closing_brace).to eq ")"
+      expect(parser.portions.size).to eq 4
+      expect(parser.portions[0]).to be_a(Keisan::StringAndGroupParser::OtherPortion)
+      expect(parser.portions[0].to_s).to eq "1 + "
+      expect(parser.portions[1]).to be_a(Keisan::StringAndGroupParser::StringPortion)
+      expect(parser.portions[1].to_s).to eq "'2'"
+      expect(parser.portions[2]).to be_a(Keisan::StringAndGroupParser::OtherPortion)
+      expect(parser.portions[2].to_s).to eq " + "
+      expect(parser.portions[3]).to be_a(Keisan::StringAndGroupParser::GroupPortion)
+      expect(parser.portions[3].to_s).to eq "[3]"
+    end
+  end
+end

--- a/spec/keisan/string_and_group_parser_spec.rb
+++ b/spec/keisan/string_and_group_parser_spec.rb
@@ -52,10 +52,17 @@ RSpec.describe Keisan::StringAndGroupParser do
     end
 
     it "handles escape characters" do
-      parser = described_class.new("1 + 'a\\\\b' + 2", 4)
+      parser = described_class.new("1 + 'a\\\\\\a\\b\\r\\n\\s\\tb' + 2", 4)
       expect(parser.start_index).to eq 4
-      expect(parser.end_index).to eq 10
-      expect(parser.string).to eq "'a\\b'"
+      expect(parser.end_index).to eq 22
+      expect(parser.string).to eq "'a\\\a\b\r\n\s\tb'"
+    end
+
+    it "handles escape quotes" do
+      parser = described_class.new("\"\\'hello\"", 0)
+      expect(parser.start_index).to eq 0
+      expect(parser.end_index).to eq 9
+      expect(parser.string).to eq "\"'hello\""
     end
 
     it "can have braces" do
@@ -63,6 +70,10 @@ RSpec.describe Keisan::StringAndGroupParser do
       expect(parser.start_index).to eq 4
       expect(parser.end_index).to eq 10
       expect(parser.string).to eq '"a()b"'
+    end
+
+    it "fails with single quote" do
+      expect { described_class.new("'", 0) }.to raise_error Keisan::Exceptions::TokenizingError
     end
 
     it "fails on incorrect start_index" do
@@ -75,6 +86,10 @@ RSpec.describe Keisan::StringAndGroupParser do
 
     it "fails on unknown escape character" do
       expect { described_class.new("'as\\cdf'", 0) }.to raise_error Keisan::Exceptions::TokenizingError
+    end
+
+    it "fails on escape character at end" do
+      expect { described_class.new("'as\\", 0) }.to raise_error Keisan::Exceptions::TokenizingError
     end
   end
 

--- a/spec/keisan/tokenizer_spec.rb
+++ b/spec/keisan/tokenizer_spec.rb
@@ -224,6 +224,32 @@ RSpec.describe Keisan::Tokenizer do
     end
 
     it "has nested groups properly tokenized" do
+      tokenizer = described_class.new("'1'+'2'+(']]') + (('3') + '4')")
+
+      expect(tokenizer.tokens.map(&:class)).to match_array([
+        Keisan::Tokens::String,
+        Keisan::Tokens::ArithmeticOperator,
+        Keisan::Tokens::String,
+        Keisan::Tokens::ArithmeticOperator,
+        Keisan::Tokens::Group,
+        Keisan::Tokens::ArithmeticOperator,
+        Keisan::Tokens::Group
+      ])
+
+      group = tokenizer.tokens[4]
+      expect(group.string).to eq "(']]')"
+      expect(group.sub_tokens.map(&:class)).to match_array([Keisan::Tokens::String])
+
+      group = tokenizer.tokens[6]
+      expect(group.string).to eq "(('3') + '4')"
+      expect(group.sub_tokens.map(&:class)).to match_array([
+        Keisan::Tokens::Group,
+        Keisan::Tokens::ArithmeticOperator,
+        Keisan::Tokens::String
+      ])
+    end
+
+    it "has nested groups properly tokenized" do
       tokenizer = described_class.new("1+(2+(3+4)+5)+(6)")
 
       expect(tokenizer.tokens.map(&:class)).to match_array([

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,4 @@
 require 'simplecov'
-require 'coveralls'
-
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-])
 SimpleCov.start
 
 require "bundler/setup"


### PR DESCRIPTION
Previously unmatched braces inside strings would cause tokenization
errors. The expected behavior is that braces inside of strings would not
participate in brace matching (as they are part of a string). This
commit handles strings/brace-groups separately, making sure to match
opening/closing braces/quotations correctly.

This fixes issue #94.