### PR TITLE
Methods to get days/seconds since Unix epoch

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ calculator.evaluate("range(1, 6).map(x, [x, x**2]).to_h")
 Keisan supports date and time objects like in Ruby.
 You create a date object using either the method `date` (either a string to be parsed, or year, month, day numerical arguments) or `today`.
 They support methods `year`, `month`, `day`, `weekday`, `strftime`, and `to_time` to convert to a time object.
+`epoch_days` computes the number of days since Unix epoch (Jan 1, 1970).
 
 ```ruby
 calculator = Keisan::Calculator.new
@@ -266,10 +267,13 @@ calculator.evaluate("today() > date(2018, 11, 1)")
 #=> true
 calculator.evaluate("date('1999-12-31').to_time + 10")
 #=> Time.new(1999, 12, 31, 0, 0, 10)
+calculator.evaluate("date(1970, 1, 15).epoch_days")
+#=> 14
 ```
 
 Time objects are created using `time` (either a string to be parsed, or year, month, day, hour, minute, second arguments) or `now`.
 They support methods `year`, `month`, `day`, `hour`, `minute`, `second`, `weekday`, `strftime`, and `to_date` to convert to a date object.
+`epoch_seconds` computes the number of seconds since Unix epoch (00:00:00 on Jan 1, 1970).
 
 ```ruby
 calculator = Keisan::Calculator.new
@@ -279,6 +283,8 @@ calculator.evaluate("time('2000-4-15 12:34:56').minute")
 #=> 34
 calculator.evaluate("time('5000-10-10 20:30:40').strftime('%b %d, %Y')")
 #=> "Oct 10, 5000"
+calculator.evaluate("time(1970, 1, 1, 2, 3, 4).epoch_seconds")
+#=> 7384
 ```
 
 ##### Functional programming methods

--- a/lib/keisan/functions/default_registry.rb
+++ b/lib/keisan/functions/default_registry.rb
@@ -147,6 +147,9 @@ module Keisan
 
         registry.register!(:to_time, Proc.new {|d| d.to_time }, force: true)
         registry.register!(:to_date, Proc.new {|t| t.to_date }, force: true)
+
+        registry.register!(:epoch_seconds, Proc.new {|d| d.to_time - Time.new(1970, 1, 1, 0, 0, 0) }, force: true)
+        registry.register!(:epoch_days, Proc.new {|t| t.to_date  - Date.new(1970, 1, 1) }, force: true)
       end
 
       def self.register_date_time!(registry)

--- a/spec/keisan/ast/date_spec.rb
+++ b/spec/keisan/ast/date_spec.rb
@@ -103,6 +103,24 @@ RSpec.describe Keisan::AST::Date do
         expect(time.to_s).to eq "2018-11-20 00:00:00"
       end
     end
+
+    describe "#epoch_days" do
+      it "returns the number of days since Unix epoch" do
+        calculator = Keisan::Calculator.new
+        time = calculator.ast("date(1970, 2, 2).epoch_days").evaluate
+        expect(time).to be_a(Keisan::AST::Number)
+        expect(time.value).to eq 32
+      end
+    end
+
+    describe "#epoch_seconds" do
+      it "returns the number of days since Unix epoch" do
+        calculator = Keisan::Calculator.new
+        time = calculator.ast("date(1970, 1, 2).epoch_seconds").evaluate
+        expect(time).to be_a(Keisan::AST::Number)
+        expect(time.value).to eq 86400
+      end
+    end
   end
 
   describe "#to_s" do

--- a/spec/keisan/ast/time_spec.rb
+++ b/spec/keisan/ast/time_spec.rb
@@ -127,6 +127,24 @@ RSpec.describe Keisan::AST::Time do
         expect(date.to_s).to eq "2018-11-20"
       end
     end
+
+    describe "#epoch_days" do
+      it "returns the number of days since Unix epoch" do
+        calculator = Keisan::Calculator.new
+        time = calculator.ast("time(1970, 2, 2, 0, 0, 0).epoch_days").evaluate
+        expect(time).to be_a(Keisan::AST::Number)
+        expect(time.value).to eq 32
+      end
+    end
+
+    describe "#epoch_seconds" do
+      it "returns the number of days since Unix epoch" do
+        calculator = Keisan::Calculator.new
+        time = calculator.ast("time(1970, 1, 2, 3, 4, 5).epoch_seconds").evaluate
+        expect(time).to be_a(Keisan::AST::Number)
+        expect(time.value).to eq 86400 + 3*3600 + 4*60 + 5
+      end
+    end
   end
 
   describe "#to_s" do

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "README.md" do
       digest = Digest::SHA256.hexdigest(content)
 
       # cat README.md | sha256sum
-      expected_digest = "91650a4c67a97cba5be0aae5ee94df3ba0b60289d5279057f662238750478eaf"
+      expected_digest = "42b218e984705d51b2864a7fc136b3bba309f17d23db76bd03460619871884d9"
       if digest != expected_digest
         raise "Invalid README file detected with SHA256 digest of #{digest}. Use command `cat README.md | sha256sum` to get correct digest if your changes to the README are safe. Aborting README test."
       end


### PR DESCRIPTION
Adds two new functions: `epoch_days` and `epoch_seconds`.  These compute the number of days/seconds respectively since Unix epoch, 00:00:00 on Jan 1st, 1970.  They can be used for instance to write a function which computes the number of days between two dates:

```
diff_days(a, b) = a.epoch_days - b.epoch_days
diff_days(date(2020, 4, 4), date(2020, 4, 1))
#=> 3
```