### PR TITLE
New flags to disallow blocks/multiline expressions

### DIFF
--- a/lib/keisan/ast/block.rb
+++ b/lib/keisan/ast/block.rb
@@ -17,6 +17,10 @@ module Keisan
         child.unbound_functions(local)
       end
 
+      def contains_a?(klass)
+        super || child.contains_a?(klass)
+      end
+
       def deep_dup
         dupped = dup
         dupped.instance_variable_set(

--- a/lib/keisan/ast/cell.rb
+++ b/lib/keisan/ast/cell.rb
@@ -15,6 +15,10 @@ module Keisan
         node.unbound_functions(context)
       end
 
+      def contains_a?(klass)
+        super || node.contains_a?(klass)
+      end
+
       def deep_dup
         dupped = dup
         dupped.instance_variable_set(

--- a/lib/keisan/ast/function_assignment.rb
+++ b/lib/keisan/ast/function_assignment.rb
@@ -37,13 +37,21 @@ module Keisan
       private
 
       def verify_rhs_of_function_assignment_is_valid!
+        verify_unbound_functions!
+        verify_unbound_variables!
+      end
+
+      def verify_unbound_functions!
         # Cannot have undefined functions unless allowed by context
         unless context.allow_recursive || rhs.unbound_functions(context).empty?
           raise Exceptions::InvalidExpression.new("Unbound function definitions are not allowed by current context")
         end
+      end
 
+      def verify_unbound_variables!
+        # We allow unbound variables inside block statements, as they could be temporary
+        # variables assigned locally
         return if rhs.is_a?(Block)
-
         # Only variables that can appear are those that are arguments to the function
         unless rhs.unbound_variables(context) <= Set.new(argument_names)
           raise Exceptions::InvalidExpression.new("Unbound variables found in function definition")

--- a/lib/keisan/ast/function_assignment.rb
+++ b/lib/keisan/ast/function_assignment.rb
@@ -29,8 +29,7 @@ module Keisan
 
       def evaluate
         # Blocks might have local variable/function definitions, so skip check
-        verify_rhs_of_function_assignment_is_valid! unless rhs.is_a?(Block)
-
+        verify_rhs_of_function_assignment_is_valid!
         context.register_function!(lhs.name, expression_function, local: local)
         rhs
       end
@@ -38,13 +37,16 @@ module Keisan
       private
 
       def verify_rhs_of_function_assignment_is_valid!
-        # Only variables that can appear are those that are arguments to the function
-        unless rhs.unbound_variables(context) <= Set.new(argument_names)
-          raise Exceptions::InvalidExpression.new("Unbound variables found in function definition")
-        end
         # Cannot have undefined functions unless allowed by context
         unless context.allow_recursive || rhs.unbound_functions(context).empty?
           raise Exceptions::InvalidExpression.new("Unbound function definitions are not allowed by current context")
+        end
+
+        return if rhs.is_a?(Block)
+
+        # Only variables that can appear are those that are arguments to the function
+        unless rhs.unbound_variables(context) <= Set.new(argument_names)
+          raise Exceptions::InvalidExpression.new("Unbound variables found in function definition")
         end
       end
     end

--- a/lib/keisan/ast/hash.rb
+++ b/lib/keisan/ast/hash.rb
@@ -21,6 +21,10 @@ module Keisan
         end
       end
 
+      def contains_a?(klass)
+        super || @hash.any? {|k, v| k.to_node.contains_a?(klass) || v.contains_a?(klass) }
+      end
+
       def evaluate(context = nil)
         context ||= Context.new
 

--- a/lib/keisan/ast/node.rb
+++ b/lib/keisan/ast/node.rb
@@ -38,7 +38,12 @@ module Keisan
       end
 
       def contains_a?(klass)
-        return is_a?(klass)
+        case klass
+        when Array
+          return klass.any? {|k| is_a?(k) }
+        else
+          return is_a?(klass)
+        end
       end
 
       def evaluate_assignments(context = nil)

--- a/lib/keisan/ast/node.rb
+++ b/lib/keisan/ast/node.rb
@@ -37,6 +37,10 @@ module Keisan
         value(context)
       end
 
+      def contains_a?(klass)
+        return is_a?(klass)
+      end
+
       def evaluate_assignments(context = nil)
         self
       end

--- a/lib/keisan/ast/node.rb
+++ b/lib/keisan/ast/node.rb
@@ -40,9 +40,9 @@ module Keisan
       def contains_a?(klass)
         case klass
         when Array
-          return klass.any? {|k| is_a?(k) }
+          klass.any? {|k| is_a?(k) }
         else
-          return is_a?(klass)
+          is_a?(klass)
         end
       end
 

--- a/lib/keisan/ast/parent.rb
+++ b/lib/keisan/ast/parent.rb
@@ -26,7 +26,7 @@ module Keisan
       end
 
       def contains_a?(klass)
-        super | children.any? {|child| child.contains_a?(klass) }
+        super || children.any? {|child| child.contains_a?(klass) }
       end
 
       def freeze

--- a/lib/keisan/ast/parent.rb
+++ b/lib/keisan/ast/parent.rb
@@ -25,6 +25,10 @@ module Keisan
         end
       end
 
+      def contains_a?(klass)
+        super | children.any? {|child| child.contains_a?(klass) }
+      end
+
       def freeze
         children.each(&:freeze)
         super

--- a/lib/keisan/calculator.rb
+++ b/lib/keisan/calculator.rb
@@ -2,8 +2,12 @@ module Keisan
   class Calculator
     attr_reader :context
 
-    def initialize(context: nil, allow_recursive: false)
-      @context = context || Context.new(allow_recursive: allow_recursive)
+    def initialize(context: nil, allow_recursive: false, allow_blocks: true, allow_multiline: true)
+      @context = context || Context.new(
+        allow_recursive: allow_recursive,
+        allow_blocks: allow_blocks,
+        allow_multiline: allow_multiline
+      )
     end
 
     def allow_recursive
@@ -23,7 +27,7 @@ module Keisan
     end
 
     def ast(expression)
-      Evaluator.new(self).ast(expression)
+      Evaluator.new(self).parse_ast(expression)
     end
 
     def define_variable!(name, value)

--- a/lib/keisan/calculator.rb
+++ b/lib/keisan/calculator.rb
@@ -2,6 +2,8 @@ module Keisan
   class Calculator
     attr_reader :context
 
+    # Note, allow_recursive would be more appropriately named:
+    # allow_unbound_functions_in_function_definitions, but it is too late for that.
     def initialize(context: nil, allow_recursive: false, allow_blocks: true, allow_multiline: true)
       @context = context || Context.new(
         allow_recursive: allow_recursive,
@@ -16,6 +18,14 @@ module Keisan
 
     def allow_recursive!
       context.allow_recursive!
+    end
+
+    def allow_blocks
+      context.allow_blocks
+    end
+
+    def allow_multiline
+      context.allow_multiline
     end
 
     def evaluate(expression, definitions = {})

--- a/lib/keisan/context.rb
+++ b/lib/keisan/context.rb
@@ -1,13 +1,24 @@
 module Keisan
   class Context
-    attr_reader :function_registry, :variable_registry, :allow_recursive
+    attr_reader :function_registry,
+      :variable_registry,
+      :allow_recursive,
+      :allow_multiline,
+      :allow_blocks
 
-    def initialize(parent: nil, random: nil, allow_recursive: false, shadowed: [])
+    def initialize(parent: nil,
+                   random: nil,
+                   allow_recursive: false,
+                   allow_multiline: true,
+                   allow_blocks: true,
+                   shadowed: [])
       @parent = parent
       @function_registry = Functions::Registry.new(parent: @parent&.function_registry)
       @variable_registry = Variables::Registry.new(parent: @parent&.variable_registry, shadowed: shadowed)
       @random            = random
       @allow_recursive   = allow_recursive
+      @allow_multiline   = allow_multiline
+      @allow_blocks      = allow_blocks
     end
 
     def allow_recursive!
@@ -110,7 +121,13 @@ module Keisan
     end
 
     def pure_child(shadowed: [])
-      self.class.new(parent: self, shadowed: shadowed, allow_recursive: allow_recursive)
+      self.class.new(
+        parent: self,
+        shadowed: shadowed,
+        allow_recursive: allow_recursive,
+        allow_multiline: allow_multiline,
+        allow_blocks: allow_blocks
+      )
     end
   end
 end

--- a/lib/keisan/evaluator.rb
+++ b/lib/keisan/evaluator.rb
@@ -30,16 +30,21 @@ module Keisan
 
     def parse_ast(expression)
       AST.parse(expression).tap do |ast|
-        if !calculator.context.allow_multiline && ast.contains_a?(Keisan::AST::MultiLine)
-          raise Keisan::Exceptions::InvalidExpression.new("Context does not permit multiline expressions")
-        end
-        if !calculator.context.allow_blocks && ast.contains_a?(Keisan::AST::Block)
-          raise Keisan::Exceptions::InvalidExpression.new("Context does not permit blocks")
+        disallowed = disallowed_nodes
+        if !disallowed.empty? && ast.contains_a?(disallowed)
+          raise Keisan::Exceptions::InvalidExpression.new("Context does not permit expressions with #{disallowed}")
         end
       end
     end
 
     private
+
+    def disallowed_nodes
+      disallowed = []
+      disallowed << Keisan::AST::Block unless calculator.allow_blocks
+      disallowed << Keisan::AST::MultiLine unless calculator.allow_multiline
+      disallowed
+    end
 
     def last_line(ast)
       ast.is_a?(AST::MultiLine) ? ast.children.last : ast

--- a/spec/keisan/ast/node_spec.rb
+++ b/spec/keisan/ast/node_spec.rb
@@ -22,6 +22,82 @@ RSpec.describe Keisan::AST::Node do
     end
   end
 
+  describe "contains_a?" do
+    it "checks type of regular node" do
+      expect(Keisan::AST::Node.new.contains_a?(Keisan::AST::Node)).to eq true
+      expect(Keisan::AST::Node.new.contains_a?(Keisan::AST::Variable)).to eq false
+      expect(Keisan::AST::Variable.new("x").contains_a?(Keisan::AST::Node)).to eq true
+      expect(Keisan::AST::Variable.new("x").contains_a?(Keisan::AST::Variable)).to eq true
+    end
+
+    it "checks content of blocks" do
+      ast = Keisan::Calculator.new.ast("{1; x}")
+
+      expect(ast.contains_a?(Keisan::AST::Node)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Block)).to eq true
+      expect(ast.contains_a?(Keisan::AST::MultiLine)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Number)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Variable)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Boolean)).to eq false
+      expect(ast.contains_a?(Keisan::AST::Times)).to eq false
+      expect(ast.contains_a?(Keisan::AST::String)).to eq false
+    end
+
+    it "checks internal node of a cell" do
+      ast = Keisan::AST::Cell.new(Keisan::AST::Number.new(5))
+
+      expect(ast.contains_a?(Keisan::AST::Node)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Cell)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Number)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Variable)).to eq false
+      expect(ast.contains_a?(Keisan::AST::Times)).to eq false
+      expect(ast.contains_a?(Keisan::AST::String)).to eq false
+    end
+
+    it "checks arguments for function calls" do
+      ast = Keisan::Calculator.new.ast("f('a')")
+
+      expect(ast.contains_a?(Keisan::AST::Node)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Function)).to eq true
+      expect(ast.contains_a?(Keisan::AST::String)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Variable)).to eq false
+    end
+
+    it "checks children for operators" do
+      ast = Keisan::Calculator.new.ast("5*x")
+
+      expect(ast.contains_a?(Keisan::AST::Node)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Times)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Function)).to eq false
+      expect(ast.contains_a?(Keisan::AST::Number)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Variable)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Plus)).to eq false
+    end
+
+    it "checks content of lists and hashes" do
+      ast = Keisan::Calculator.new.ast("[1, '2']")
+
+      expect(ast.contains_a?(Keisan::AST::Node)).to eq true
+      expect(ast.contains_a?(Keisan::AST::List)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Hash)).to eq false
+      expect(ast.contains_a?(Keisan::AST::Number)).to eq true
+      expect(ast.contains_a?(Keisan::AST::String)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Variable)).to eq false
+      expect(ast.contains_a?(Keisan::AST::Boolean)).to eq false
+
+      ast = Keisan::Calculator.new.ast("{true: f(true)}")
+
+      expect(ast.contains_a?(Keisan::AST::Node)).to eq true
+      expect(ast.contains_a?(Keisan::AST::List)).to eq false
+      expect(ast.contains_a?(Keisan::AST::Hash)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Number)).to eq false
+      expect(ast.contains_a?(Keisan::AST::String)).to eq false
+      expect(ast.contains_a?(Keisan::AST::Variable)).to eq false
+      expect(ast.contains_a?(Keisan::AST::Boolean)).to eq true
+      expect(ast.contains_a?(Keisan::AST::Function)).to eq true
+    end
+  end
+
   describe "operators" do
     it "combines the AST appropriately" do
       x = Keisan::AST::Variable.new("x")

--- a/spec/keisan/ast/node_spec.rb
+++ b/spec/keisan/ast/node_spec.rb
@@ -96,6 +96,14 @@ RSpec.describe Keisan::AST::Node do
       expect(ast.contains_a?(Keisan::AST::Boolean)).to eq true
       expect(ast.contains_a?(Keisan::AST::Function)).to eq true
     end
+
+    it "can check multiple classes at once" do
+      ast = Keisan::Calculator.new.ast("5*x")
+
+      expect(ast.contains_a?([Keisan::AST::Number, Keisan::AST::String])).to eq true
+      expect(ast.contains_a?([Keisan::AST::Boolean, Keisan::AST::String])).to eq false
+      expect(ast.contains_a?([Keisan::AST::Times, Keisan::AST::String])).to eq true
+    end
   end
 
   describe "operators" do

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe Keisan::Calculator do
       end
     end
 
-    context "recursive" do
+    describe "allow_recursive" do
       context "cannot define recursive functions" do
         let(:calculator) { described_class.new(allow_recursive: false) }
 
@@ -279,6 +279,62 @@ RSpec.describe Keisan::Calculator do
           expect(calculator.evaluate("my_fact(0)")).to eq 1
           expect(calculator.evaluate("my_fact(1)")).to eq 1
           expect(calculator.evaluate("my_fact(5)")).to eq 120
+        end
+      end
+    end
+
+    describe "allow_blocks" do
+      context "cannot define blocks" do
+        let(:calculator) { described_class.new(allow_blocks: false) }
+
+        it "raises an exception when receiving an expression with a block" do
+          expect {
+            calculator.evaluate("f(x) = (1; x**2)")
+          }.not_to raise_error
+          expect {
+            calculator.evaluate("f(x) = { 1; x**2 }")
+          }.to raise_error(Keisan::Exceptions::InvalidExpression)
+        end
+      end
+
+      context "can define blocks" do
+        let(:calculator) { described_class.new(allow_blocks: true) }
+
+        it "raises an exception when receiving an expression with a block" do
+          expect {
+            calculator.evaluate("f(x) = (1; x**2)")
+          }.not_to raise_error
+          expect {
+            calculator.evaluate("f(x) = { 1; x**2 }")
+          }.not_to raise_error
+        end
+      end
+    end
+
+    describe "allow_multiline" do
+      context "cannot define multiline" do
+        let(:calculator) { described_class.new(allow_multiline: false) }
+
+        it "raises an exception when receiving an expression with multiple lines" do
+          expect {
+            calculator.evaluate("f(x) = { 1 + x**2 }")
+          }.not_to raise_error
+          expect {
+            calculator.evaluate("f(x) = { 1; x**2 }")
+          }.to raise_error(Keisan::Exceptions::InvalidExpression)
+        end
+      end
+
+      context "can define multiline" do
+        let(:calculator) { described_class.new(allow_multiline: true) }
+
+        it "raises an exception when receiving an expression with a block" do
+          expect {
+            calculator.evaluate("f(x) = { 1 + x**2 }")
+          }.not_to raise_error
+          expect {
+            calculator.evaluate("f(x) = { 1; x**2 }")
+          }.not_to raise_error
         end
       end
     end

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -258,9 +258,15 @@ RSpec.describe Keisan::Calculator do
       context "cannot define recursive functions" do
         let(:calculator) { described_class.new(allow_recursive: false) }
 
-        it "can define factorial" do
+        it "raises an exception when defining a recursive function" do
           expect {
             calculator.evaluate("my_fact(n) = if (n > 1, n*my_fact(n-1), 1)")
+          }.to raise_error(Keisan::Exceptions::InvalidExpression)
+          expect {
+            calculator.evaluate("my_fact(n) = { if (n > 1, n*my_fact(n-1), 1) }")
+          }.to raise_error(Keisan::Exceptions::InvalidExpression)
+          expect {
+            calculator.evaluate("my_fact(n) = if (n > 1, { n*my_fact(n-1) }, 1)")
           }.to raise_error(Keisan::Exceptions::InvalidExpression)
         end
       end


### PR DESCRIPTION
These new options can be used to further lock-down the expressions that are permitted by the calculator class.  