### PR TITLE
Handle comments separately from strings

### DIFF
--- a/lib/keisan/tokenizer.rb
+++ b/lib/keisan/tokenizer.rb
@@ -24,9 +24,11 @@ module Keisan
     attr_reader :expression, :tokens
 
     def initialize(expression)
-      @expression = self.class.normalize_expression(expression)
+      @expression = expression
 
-      portions = StringAndGroupParser.new(@expression).portions
+      portions = StringAndGroupParser.new(expression).portions.reject do |portion|
+        portion.is_a? StringAndGroupParser::CommentPortion
+      end
 
       @tokens = portions.inject([]) do |tokens, portion|
         case portion
@@ -43,20 +45,7 @@ module Keisan
       end
     end
 
-    def self.normalize_expression(expression)
-      expression = normalize_line_delimiters(expression)
-      expression = remove_comments(expression)
-    end
-
     private
-
-    def self.normalize_line_delimiters(expression)
-      expression.gsub(/\n/, ";")
-    end
-
-    def self.remove_comments(expression)
-      expression.gsub(/#[^;]*/, "")
-    end
 
     def tokenize!(scan)
       scan.map do |scan_result|

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Keisan::Calculator do
     expect(calculator.evaluate("# Hello world")).to eq nil
     expect(calculator.evaluate("2 + 3 # 4")).to eq 5
     expect(calculator.evaluate("# Initial comment\n 1+2\n 123 # Real result\n# Trailing comment\n")).to eq 123
+    expect(calculator.evaluate("# Blah )(('\"\n 'foo' + '#bar' #Ignore")).to eq "foo#bar"
   end
 
   it "can handle custom functions" do

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Keisan::Calculator do
 
   describe "unmatched braces inside strings" do
     it "does not match against actual braces outside strings" do
-      expect(calculator.evaluate("'1'+'2'+(']\n]') + (('3') + '4')")).to eq "12];]34"
+      expect(calculator.evaluate("'1'+'2'+(']\n]') + (('3') + '4')")).to eq "12]\n]34"
     end
   end
 

--- a/spec/keisan/string_and_group_parser_spec.rb
+++ b/spec/keisan/string_and_group_parser_spec.rb
@@ -65,6 +65,13 @@ RSpec.describe Keisan::StringAndGroupParser do
       expect(parser.string).to eq "\"'hello\""
     end
 
+    it "handles #hashtags quotes" do
+      parser = described_class.new("'foo #bar'", 0)
+      expect(parser.start_index).to eq 0
+      expect(parser.end_index).to eq 10
+      expect(parser.string).to eq "'foo #bar'"
+    end
+
     it "can have braces" do
       parser = described_class.new("1 + \"a()b\" + 2", 4)
       expect(parser.start_index).to eq 4
@@ -118,6 +125,34 @@ RSpec.describe Keisan::StringAndGroupParser do
       expect(parser.portions[2].to_s).to eq " + "
       expect(parser.portions[3]).to be_a(Keisan::StringAndGroupParser::GroupPortion)
       expect(parser.portions[3].to_s).to eq "[3]"
+    end
+  end
+
+  describe described_class::CommentPortion do
+    it "parses comment up to end of string" do
+      parser = described_class.new("# Hello", 0)
+      expect(parser.start_index).to eq 0
+      expect(parser.end_index).to eq 7
+      expect(parser.string).to eq "# Hello"
+
+      parser = described_class.new("foo # bar", 4)
+      expect(parser.start_index).to eq 4
+      expect(parser.end_index).to eq 9
+      expect(parser.string).to eq "# bar"
+    end
+
+    it "parses comment up to end of line if newline found" do
+      parser = described_class.new("# Hello\nx + 1", 0)
+      expect(parser.start_index).to eq 0
+      expect(parser.end_index).to eq 7
+      expect(parser.string).to eq "# Hello"
+    end
+
+    it "handles braces and quotes fine in comments" do
+      parser = described_class.new("# )'\"(\n'hi'", 0)
+      expect(parser.start_index).to eq 0
+      expect(parser.end_index).to eq 6
+      expect(parser.string).to eq "# )'\"("
     end
   end
 end

--- a/spec/keisan/tokenizer_spec.rb
+++ b/spec/keisan/tokenizer_spec.rb
@@ -223,6 +223,30 @@ RSpec.describe Keisan::Tokenizer do
       end
     end
 
+    it "handles #hashtags in strings" do
+      tokenizer = described_class.new("1 - 2 # Comm'ent\nx + '#math' # Anot'her comment")
+
+      expect(tokenizer.tokens.map(&:class)).to match_array([
+        Keisan::Tokens::Number,
+        Keisan::Tokens::ArithmeticOperator,
+        Keisan::Tokens::Number,
+        Keisan::Tokens::LineSeparator,
+        Keisan::Tokens::Word,
+        Keisan::Tokens::ArithmeticOperator,
+        Keisan::Tokens::String
+      ])
+
+      expect(tokenizer.tokens.map(&:string)).to match_array([
+        "1",
+        "-",
+        "2",
+        "\n",
+        "x",
+        "+",
+        "'#math'"
+      ])
+    end
+
     it "has nested groups properly tokenized" do
       tokenizer = described_class.new("'1'+'2'+(']]') + (('3') + '4')")
 


### PR DESCRIPTION
Resolves #101

Previously, due to inconsistent handling of stripping out comments in combination with strings, hashtags `#` caused problems.  This PR fixes the problem by ensuring that when a hashtag character is encountered outside of a string, all characters up to the end of the string or the next new-line character are considered comments and stripped out.