### PR TITLE
Update version to 0.8.4

### DIFF
--- a/lib/keisan/version.rb
+++ b/lib/keisan/version.rb
@@ -1,3 +1,3 @@
 module Keisan
-  VERSION = "0.8.3"
+  VERSION = "0.8.4"
 end

--- a/spec/keisan_spec.rb
+++ b/spec/keisan_spec.rb
@@ -1,10 +1,6 @@
 require "spec_helper"
 
 RSpec.describe Keisan do
-  it "has the expected version number" do
-    expect(Keisan::VERSION).to eq "0.8.3"
-  end
-
   context "module methods" do
     after do
       # Want to reset the calculator internal to Keisan after each spec

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,0 +1,7 @@
+require "spec_helper"
+
+RSpec.describe Keisan do
+  it "has the expected version number" do
+    expect(Keisan::VERSION).to eq "0.8.4"
+  end
+end


### PR DESCRIPTION
Incorporates changes from #102 which fixes how comments are stripped out when strings are encountered with the `#` character.