### PR TITLE
Fix handling of escaped characters within brackets

### DIFF
--- a/lib/keisan/tokenizer.rb
+++ b/lib/keisan/tokenizer.rb
@@ -33,7 +33,7 @@ module Keisan
       @tokens = portions.inject([]) do |tokens, portion|
         case portion
         when StringAndGroupParser::StringPortion
-          tokens << Tokens::String.new(portion.to_s)
+          tokens << Tokens::String.new(portion.escaped_string)
         when StringAndGroupParser::GroupPortion
           tokens << Tokens::Group.new(portion.to_s)
         when StringAndGroupParser::OtherPortion

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -172,6 +172,15 @@ RSpec.describe Keisan::Calculator do
       expect(ast.children[1]).to be_a(Keisan::AST::Number)
       expect(ast.children[1].value).to eq 1
     end
+
+    it "works with strings inside groups" do
+      expect(calculator.ast('"a"').value).to eq 'a'
+      expect(calculator.ast('"\"a"').value).to eq '"a'
+      expect(calculator.ast('("\"a")').value).to eq '"a'
+      expect(calculator.ast('("\"a" + "\"")').value).to eq '"a"'
+      expect(calculator.ast(%q{("\"a\'")}).value).to eq '"a\''
+      expect(calculator.ast(%q{("\"a)\'[")}).value).to eq '"a)\'['
+    end
   end
 
   describe "defining variables and functions" do

--- a/spec/keisan/parser_spec.rb
+++ b/spec/keisan/parser_spec.rb
@@ -202,6 +202,17 @@ RSpec.describe Keisan::Parser do
           ])
         end
       end
+
+      it "handles escaped characters inside strings inside groups" do
+        parser = described_class.new(string: '("\"a\"")')
+        expect(parser.components.map(&:class)).to match_array([
+          Keisan::Parsing::RoundGroup,
+        ])
+        expect(parser.components[0].components.map(&:class)).to match_array([
+          Keisan::Parsing::String,
+        ])
+        expect(parser.components[0].components[0].value).to eq '"a"'
+      end
     end
 
     context "has nested brackets" do

--- a/spec/keisan/string_and_group_parser_spec.rb
+++ b/spec/keisan/string_and_group_parser_spec.rb
@@ -55,14 +55,30 @@ RSpec.describe Keisan::StringAndGroupParser do
       parser = described_class.new("1 + 'a\\\\\\a\\b\\r\\n\\s\\tb' + 2", 4)
       expect(parser.start_index).to eq 4
       expect(parser.end_index).to eq 22
-      expect(parser.string).to eq "'a\\\a\b\r\n\s\tb'"
+      expect(parser.escaped_string).to eq "'a\\\a\b\r\n\s\tb'"
+      expect(parser.string).to eq %q{'a\\\\\\a\\b\\r\\n\\s\\tb'}
     end
 
     it "handles escape quotes" do
       parser = described_class.new("\"\\'hello\"", 0)
       expect(parser.start_index).to eq 0
       expect(parser.end_index).to eq 9
-      expect(parser.string).to eq "\"'hello\""
+      expect(parser.escaped_string).to eq "\"'hello\""
+      expect(parser.string).to eq "\"\\'hello\""
+    end
+
+    it "can have escaped strings internal" do
+      expect(described_class.new(%q{"1"}, 0).string).to eq %q{"1"}
+      expect(described_class.new(%q{"\"1"}, 0).escaped_string).to eq %q{""1"}
+      expect(described_class.new(%q{"\"1"}, 0).string).to eq %q{"\"1"}
+      expect(described_class.new(%q{"\"1\'"}, 0).escaped_string).to eq %q{""1'"}
+      expect(described_class.new(%q{"\"1\'"}, 0).string).to eq %q{"\"1\'"}
+      expect(described_class.new(%q{'1'}, 0).escaped_string).to eq %q{'1'}
+      expect(described_class.new(%q{'1'}, 0).string).to eq %q{'1'}
+      expect(described_class.new(%q{'\'1'}, 0).escaped_string).to eq %q{''1'}
+      expect(described_class.new(%q{'\'1'}, 0).string).to eq %q{'\'1'}
+      expect(described_class.new(%q{'\'1\"'}, 0).escaped_string).to eq %q{''1"'}
+      expect(described_class.new(%q{'\'1\"'}, 0).string).to eq %q{'\'1\"'}
     end
 
     it "handles #hashtags quotes" do
@@ -125,6 +141,41 @@ RSpec.describe Keisan::StringAndGroupParser do
       expect(parser.portions[2].to_s).to eq " + "
       expect(parser.portions[3]).to be_a(Keisan::StringAndGroupParser::GroupPortion)
       expect(parser.portions[3].to_s).to eq "[3]"
+    end
+
+    it "can contain strings safely" do
+      parser = described_class.new(%q{("1")}, 0)
+      expect(parser.portions.size).to eq 1
+      expect(parser.portions[0]).to be_a(Keisan::StringAndGroupParser::StringPortion)
+      expect(parser.portions[0].to_s).to eq %q{"1"}
+
+      parser = described_class.new(%q{("\"1")}, 0)
+      expect(parser.portions.size).to eq 1
+      expect(parser.portions[0]).to be_a(Keisan::StringAndGroupParser::StringPortion)
+      expect(parser.portions[0].escaped_string).to eq %q{""1"}
+      expect(parser.portions[0].to_s).to eq %q{"\\"1"}
+
+      parser = described_class.new(%q{["\"1\'" + "2"]}, 0)
+      expect(parser.portions.size).to eq 3
+      expect(parser.portions[0]).to be_a(Keisan::StringAndGroupParser::StringPortion)
+      expect(parser.portions[0].escaped_string).to eq %q{""1'"}
+      expect(parser.portions[0].to_s).to eq %q{"\\"1\\'"}
+      expect(parser.portions[1]).to be_a(Keisan::StringAndGroupParser::OtherPortion)
+      expect(parser.portions[1].to_s).to eq " + "
+      expect(parser.portions[2]).to be_a(Keisan::StringAndGroupParser::StringPortion)
+      expect(parser.portions[2].escaped_string).to eq %q{"2"}
+      expect(parser.portions[2].to_s).to eq %q{"2"}
+
+      parser = described_class.new(%q[{'\'1\"' + '2'}], 0)
+      expect(parser.portions.size).to eq 3
+      expect(parser.portions[0]).to be_a(Keisan::StringAndGroupParser::StringPortion)
+      expect(parser.portions[0].escaped_string).to eq %q{''1"'}
+      expect(parser.portions[0].to_s).to eq %q{'\\'1\\"'}
+      expect(parser.portions[1]).to be_a(Keisan::StringAndGroupParser::OtherPortion)
+      expect(parser.portions[1].to_s).to eq " + "
+      expect(parser.portions[2]).to be_a(Keisan::StringAndGroupParser::StringPortion)
+      expect(parser.portions[2].escaped_string).to eq %q{'2'}
+      expect(parser.portions[2].to_s).to eq %q{'2'}
     end
   end
 

--- a/spec/keisan/tokenizer_spec.rb
+++ b/spec/keisan/tokenizer_spec.rb
@@ -321,6 +321,20 @@ RSpec.describe Keisan::Tokenizer do
       expect(tokenizer.tokens[1].string).to eq "*"
       expect(tokenizer.tokens[2].string).to eq "(3+4)"
     end
+
+    it "handles strings with escaped characters inside parentheses" do
+      tokenizer = described_class.new(%q{("\"foo")})
+      expect(tokenizer.tokens.map(&:class)).to match_array([
+        Keisan::Tokens::Group,
+      ])
+      expect(tokenizer.tokens[0].sub_tokens.map(&:class)).to match_array([
+        Keisan::Tokens::String,
+      ])
+      expect(tokenizer.tokens[0].sub_tokens[0].value).to eq '"foo'
+
+      tokenizer = described_class.new('("\"a\"()\"")')
+      expect(tokenizer.tokens[0].sub_tokens[0].value).to eq '"a"()"'
+    end
   end
 
   context "logical operators" do


### PR DESCRIPTION
Fixes #105 

There was a problem with the way escaped characters was handled that this PR fixes. Previously the distinction between the raw underlying string and the escaped version of a string was not made clear.

When parsing something like `("\"a")`, our parser would identify this as a StringAndGroupParser::GroupPortion (the outer round brackets) with an interior StringPortion correctly. However, the interior StringPortion will have converted the escaped double-quote into a double-quote character, and so the `to_s` method would return the string `""a"`. Due to the way GroupPortion is handled in Keisan::Tokenizer, the part inside the parenthesis is recursively passed into another Tokenizer object using the content of the StringPortion as input. However, the `to_s` method of the StringPortion returns this escaped string `""a"`, and so we then get mismatched quote errors which cause cascading problems.

The solution is to store the underlying raw string alongside the escaped string that ultimately the end-user wants to see, where the raw string is passed on to recursive Tokenizer objects, but when creating a Tokens::String object the escaped string is used.

Here is the new code in action using the test cases provided by @paulholden2 in #105:

```ruby
➜  keisan git:(fix_escaped_string_error) bin/console 
[1] pry(main)> Keisan::Calculator.new.ast('"a"')
=> #<Keisan::AST::String:0x00005605f86207b0 @content="a">
[2] pry(main)> Keisan::Calculator.new.ast('"\"a"')
=> #<Keisan::AST::String:0x00005605f8b5c710 @content="\"a">
[3] pry(main)> Keisan::Calculator.new.ast('("\"a")')
=> #<Keisan::AST::String:0x00005605f83e6120 @content="\"a">
[4] pry(main)> Keisan::Calculator.new.ast('my_fn("\"a")')
=> #<Keisan::AST::Function:0x00005605f8717e48 @children=[#<Keisan::AST::String:0x00005605f8710328 @content="\"a">], @name="my_fn">
[5] pry(main)> Keisan::Calculator.new.ast('("\"a\"")').to_s
=> "\"\\\"a\\\"\""
```