### PR TITLE
Add set random method to context

### DIFF
--- a/lib/keisan/context.rb
+++ b/lib/keisan/context.rb
@@ -111,7 +111,11 @@ module Keisan
     end
 
     def random
-      @random || @parent&.random || Random.new
+      @random ||= @parent&.random || Random.new
+    end
+
+    def set_random(random)
+      @random = random
     end
 
     protected

--- a/lib/keisan/version.rb
+++ b/lib/keisan/version.rb
@@ -1,3 +1,3 @@
 module Keisan
-  VERSION = "0.8.6"
+  VERSION = "0.8.7"
 end

--- a/spec/keisan/context_spec.rb
+++ b/spec/keisan/context_spec.rb
@@ -166,6 +166,25 @@ RSpec.describe Keisan::Context do
 
       expect(matches.any? {|bool| bool == false}).to be true
     end
+
+    it "has the random object set once and only once" do
+      context = described_class.new
+      random = context.random
+      expect(random).to eq context.random
+    end
+
+    it "can be set to override existing internal random object" do
+      rand1 = Random.new(2244)
+      rand1_copy = Random.new(2244)
+      rand2 = Random.new(4466)
+
+      context = described_class.new(random: rand2)
+      context.set_random(rand1_copy)
+
+      20.times do
+        expect(context.random.rand(100)).to eq rand1.rand(100)
+      end
+    end
   end
 
   describe "has_variable?" do

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -2,6 +2,6 @@ require "spec_helper"
 
 RSpec.describe Keisan do
   it "has the expected version number" do
-    expect(Keisan::VERSION).to eq "0.8.6"
+    expect(Keisan::VERSION).to eq "0.8.7"
   end
 end


### PR DESCRIPTION
Creates a new method `set_random` to `Context`. This allows one to override the Random instance used by a Context object. The `random` method has also been updated to not constantly make a new Random object if called multiple times when `@random` is not set.