### PR TITLE
allow_random toggles validity of random methods

### DIFF
--- a/lib/keisan/calculator.rb
+++ b/lib/keisan/calculator.rb
@@ -4,11 +4,12 @@ module Keisan
 
     # Note, allow_recursive would be more appropriately named:
     # allow_unbound_functions_in_function_definitions, but it is too late for that.
-    def initialize(context: nil, allow_recursive: false, allow_blocks: true, allow_multiline: true)
+    def initialize(context: nil, allow_recursive: false, allow_blocks: true, allow_multiline: true, allow_random: true)
       @context = context || Context.new(
         allow_recursive: allow_recursive,
         allow_blocks: allow_blocks,
-        allow_multiline: allow_multiline
+        allow_multiline: allow_multiline,
+        allow_random: allow_random
       )
     end
 
@@ -26,6 +27,10 @@ module Keisan
 
     def allow_multiline
       context.allow_multiline
+    end
+
+    def allow_random
+      context.allow_random
     end
 
     def evaluate(expression, definitions = {})

--- a/lib/keisan/context.rb
+++ b/lib/keisan/context.rb
@@ -4,13 +4,15 @@ module Keisan
       :variable_registry,
       :allow_recursive,
       :allow_multiline,
-      :allow_blocks
+      :allow_blocks,
+      :allow_random
 
     def initialize(parent: nil,
                    random: nil,
                    allow_recursive: false,
                    allow_multiline: true,
                    allow_blocks: true,
+                   allow_random: true,
                    shadowed: [])
       @parent = parent
       @function_registry = Functions::Registry.new(parent: @parent&.function_registry)
@@ -19,6 +21,7 @@ module Keisan
       @allow_recursive   = allow_recursive
       @allow_multiline   = allow_multiline
       @allow_blocks      = allow_blocks
+      @allow_random      = allow_random
     end
 
     def allow_recursive!
@@ -111,10 +114,12 @@ module Keisan
     end
 
     def random
+      raise Keisan::Exceptions::InvalidExpression.new("Context does not permit expressions with randomness") unless allow_random
       @random ||= @parent&.random || Random.new
     end
 
     def set_random(random)
+      raise Keisan::Exceptions::InvalidExpression.new("Context does not permit expressions with randomness") unless allow_random
       @random = random
     end
 

--- a/spec/keisan/default_functions_spec.rb
+++ b/spec/keisan/default_functions_spec.rb
@@ -194,6 +194,12 @@ RSpec.describe Keisan::Functions::DefaultRegistry do
         expect(calc1.evaluate("rand(100)")).to eq calc2.evaluate("rand(100)")
       end
     end
+
+    it "doesn't work when allow_random is false" do
+      calculator = Keisan::Calculator.new(allow_random: false)
+      expect{calculator.evaluate("rand(100)")}.to raise_error(Keisan::Exceptions::InvalidExpression)
+      expect{calculator.evaluate("sample([1, 2, 3])")}.to raise_error(Keisan::Exceptions::InvalidExpression)
+    end
   end
 
   context "combinatorical methods" do


### PR DESCRIPTION
If this flag is set to false, then evaluation of random methods,
`rand` and `sample`, will raise an error.