### PR TITLE
Multiple assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ calculator.evaluate("3*x + 1")
 #=> 61
 ```
 
+To perform multiple assigments, lists can be used
+
+```ruby
+calculator = Keisan::Calculator.new
+calculator.evaluate("x = [1, 2]")
+calculator.evaluate("[x[1], y] = [11, 22]")
+calculator.evaluate("x")
+#=> [1, 11]
+calculator.evaluate("y")
+#=> 22
+```
+
 
 ##### Specifying functions
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ calculator.evaluate("3*x + 1")
 #=> 61
 ```
 
-To perform multiple assigments, lists can be used
+To perform multiple assignments, lists can be used
 
 ```ruby
 calculator = Keisan::Calculator.new

--- a/lib/keisan/ast/assignment.rb
+++ b/lib/keisan/ast/assignment.rb
@@ -1,5 +1,6 @@
 require_relative "variable_assignment"
 require_relative "function_assignment"
+require_relative "list_assignment"
 require_relative "cell_assignment"
 
 module Keisan
@@ -31,6 +32,8 @@ module Keisan
           evaluate_variable_assignment(context, lhs, rhs)
         elsif is_function_definition?
           evaluate_function_assignment(context, lhs, rhs)
+        elsif is_list_assignment?
+          evaluate_list_assignment(context, lhs, rhs)
         else
           # Try cell assignment
           evaluate_cell_assignment(context, lhs, rhs)
@@ -71,6 +74,10 @@ module Keisan
         children.first.is_a?(Function)
       end
 
+      def is_list_assignment?
+        children.first.is_a?(List)
+      end
+
       private
 
       def evaluate_variable_assignment(context, lhs, rhs)
@@ -80,6 +87,10 @@ module Keisan
       def evaluate_function_assignment(context, lhs, rhs)
         raise Exceptions::InvalidExpression.new("Cannot do compound assignment on functions") if compound_operator
         FunctionAssignment.new(context, lhs, rhs, local).evaluate
+      end
+
+      def evaluate_list_assignment(context, lhs, rhs)
+        ListAssignment.new(self, context, lhs, rhs).evaluate
       end
 
       def evaluate_cell_assignment(context, lhs, rhs)

--- a/lib/keisan/ast/list_assignment.rb
+++ b/lib/keisan/ast/list_assignment.rb
@@ -14,10 +14,10 @@ module Keisan
         rhs = @rhs.evaluate(context)
 
         if !rhs.is_a?(List)
-          raise Exceptions::InvalidExpression.new("To do multiple assigment, RHS must be a list")
+          raise Exceptions::InvalidExpression.new("To do multiple assignment, RHS must be a list")
         end
         if lhs.children.size != rhs.children.size
-          raise Exceptions::InvalidExpression.new("To do multiple assigment, RHS list must have same length as LHS list")
+          raise Exceptions::InvalidExpression.new("To do multiple assignment, RHS list must have same length as LHS list")
         end
 
         i = 0

--- a/lib/keisan/ast/list_assignment.rb
+++ b/lib/keisan/ast/list_assignment.rb
@@ -1,0 +1,38 @@
+module Keisan
+  module AST
+    class ListAssignment
+      attr_reader :assignment, :context, :lhs, :rhs
+
+      def initialize(assignment, context, lhs, rhs)
+        @assignment = assignment
+        @context = context
+        @lhs = lhs
+        @rhs = rhs
+      end
+
+      def evaluate
+        rhs = @rhs.evaluate(context)
+
+        if !rhs.is_a?(List)
+          raise Exceptions::InvalidExpression.new("To do multiple assigment, RHS must be a list")
+        end
+        if lhs.children.size != rhs.children.size
+          raise Exceptions::InvalidExpression.new("To do multiple assigment, RHS list must have same length as LHS list")
+        end
+
+        i = 0
+        while i < lhs.children.size
+          lhs_variable = lhs.children[i]
+          rhs_assignment = rhs.children[i]
+          individual_assignment = Assignment.new(
+            children = [lhs_variable, rhs_assignment],
+            local: assignment.local,
+            compound_operator: assignment.compound_operator
+          )
+          individual_assignment.evaluate(context)
+          i += 1
+        end
+      end
+    end
+  end
+end

--- a/lib/keisan/variables/registry.rb
+++ b/lib/keisan/variables/registry.rb
@@ -1,3 +1,5 @@
+require "set"
+
 module Keisan
   module Variables
     class Registry
@@ -5,7 +7,7 @@ module Keisan
 
       def initialize(variables: {}, shadowed: [], parent: nil, use_defaults: true, force: false)
         @hash = {}
-        @shadowed = Set.new(shadowed.map(&:to_s))
+        @shadowed = ::Set.new(shadowed.map(&:to_s))
         @parent = parent
         @use_defaults = use_defaults
 

--- a/lib/keisan/version.rb
+++ b/lib/keisan/version.rb
@@ -1,3 +1,3 @@
 module Keisan
-  VERSION = "0.8.10"
+  VERSION = "0.8.11"
 end

--- a/spec/keisan/ast/assignment_spec.rb
+++ b/spec/keisan/ast/assignment_spec.rb
@@ -204,6 +204,58 @@ RSpec.describe Keisan::AST::Assignment do
       end
     end
 
+
+    context "LHS is a list" do
+      context "list assignment" do
+        it "works when lhs is a list of variables and rhs is a list of same length" do
+          context = Keisan::Context.new
+          ast = Keisan::AST.parse("[a, b] = [1, 2]")
+
+          expect(context.has_variable?("a")).to eq false
+          expect(context.has_variable?("b")).to eq false
+          ast.evaluate(context)
+          expect(context.has_variable?("a")).to eq true
+          expect(context.has_variable?("b")).to eq true
+
+          expect(context.variable("a").value).to eq 1
+          expect(context.variable("b").value).to eq 2
+        end
+
+        it "can do compound operators" do
+          context = Keisan::Context.new
+          Keisan::AST.parse("x = 3").evaluate(context)
+
+          expect(context.has_variable?("x")).to eq true
+          expect(context.has_variable?("y")).to eq false
+          expect(context.variable("x").value).to eq 3
+
+          ast = Keisan::AST.parse("[x, y] = [4, 5]")
+
+          ast.evaluate(context)
+
+          expect(context.has_variable?("x")).to eq true
+          expect(context.has_variable?("y")).to eq true
+          expect(context.variable("x").value).to eq 4
+          expect(context.variable("y").value).to eq 5
+        end
+
+        it "can do compound operators" do
+          context = Keisan::Context.new
+          Keisan::AST.parse("x = [1, 2]").evaluate(context)
+          Keisan::AST.parse("y = {'a': 4, 'b': 5}").evaluate(context)
+
+          ast = Keisan::AST.parse("[x[0], y['b']] += [10, x[1]]")
+
+          ast.evaluate(context)
+
+          expect(context.has_variable?("x")).to eq true
+          expect(context.has_variable?("y")).to eq true
+          expect(context.variable("x").value).to eq([11, 2])
+          expect(context.variable("y").value).to eq({'a' => 4, 'b' => 7})
+        end
+      end
+    end
+
     context "function that uses previously defined variable" do
       it "shadows variables within function definitions" do
         context = Keisan::Context.new

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "README.md" do
       digest = Digest::SHA256.hexdigest(content)
 
       # cat README.md | sha256sum
-      expected_digest = "937adb8d7080b2ea309674504a421b32af714fae4cf1257dc1a58a88e970f0e0"
+      expected_digest = "fcbb83dd135ce76797f51dcc817c530b80e4cd23e4e00a788e6be72004ba4a89"
       if digest != expected_digest
         raise "Invalid README file detected with SHA256 digest of #{digest}. Use command `cat README.md | sha256sum` to get correct digest if your changes to the README are safe. Aborting README test."
       end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "README.md" do
       digest = Digest::SHA256.hexdigest(content)
 
       # cat README.md | sha256sum
-      expected_digest = "fcbb83dd135ce76797f51dcc817c530b80e4cd23e4e00a788e6be72004ba4a89"
+      expected_digest = "e4a52a0f15d13f3edbba2caadb59c7aba7627c3be2623173e4bbc2e531362076"
       if digest != expected_digest
         raise "Invalid README file detected with SHA256 digest of #{digest}. Use command `cat README.md | sha256sum` to get correct digest if your changes to the README are safe. Aborting README test."
       end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -2,6 +2,6 @@ require "spec_helper"
 
 RSpec.describe Keisan do
   it "has the expected version number" do
-    expect(Keisan::VERSION).to eq "0.8.10"
+    expect(Keisan::VERSION).to eq "0.8.11"
   end
 end


### PR DESCRIPTION
New feature: multiple assignments can now be performed in a single line. To do this, you wrap the assignments in a list on both sides. For instance, to assign to two variables:

```
[x, y] = [3, 5]
```

This works in the following manner:
- The RHS is evaluated
- If the RHS is not a list or of different length than the LHS, then an error is raise
- Finally the individual assignments are performed from left to right (e.g. "[a, b, c] = [1, 2, 3]" first does "a = 1", then "b = 2", then "c = 3")
- This has all the same features of normal assignment, e.g. compound operators like `+=` can be used, or assignment to individual list / hash elements can be done.