### PR TITLE
Fix boolean checks when embedded in a cell

### DIFF
--- a/lib/keisan/ast/cell.rb
+++ b/lib/keisan/ast/cell.rb
@@ -66,7 +66,7 @@ module Keisan
       end
 
       def to_cell
-        self.class.new(node.to_cell)
+        self.class.new(node.to_node)
       end
 
       def to_s

--- a/lib/keisan/ast/logical_and.rb
+++ b/lib/keisan/ast/logical_and.rb
@@ -26,7 +26,7 @@ module Keisan
 
       def short_circuit_do(method, context)
         context ||= Context.new
-        lhs = children[0].send(method, context)
+        lhs = children[0].send(method, context).to_node
         case lhs
         when AST::Boolean
           lhs.false? ? AST::Boolean.new(false) : children[1].send(method, context)

--- a/lib/keisan/ast/logical_or.rb
+++ b/lib/keisan/ast/logical_or.rb
@@ -26,7 +26,7 @@ module Keisan
 
       def short_circuit_do(method, context)
         context ||= Context.new
-        lhs = children[0].send(method, context)
+        lhs = children[0].send(method, context).to_node
         case lhs
         when AST::Boolean
           lhs.true? ? AST::Boolean.new(true) : children[1].send(method, context)

--- a/lib/keisan/functions/filter.rb
+++ b/lib/keisan/functions/filter.rb
@@ -29,7 +29,7 @@ module Keisan
         AST::List.new(
           list.children.select do |element|
             local.register_variable!(variable, element)
-            result = expression.evaluated(local)
+            result = expression.evaluated(local).to_node
 
             case result
             when AST::Boolean
@@ -54,7 +54,7 @@ module Keisan
           hash.select do |cur_key, cur_value|
             local.register_variable!(key, cur_key)
             local.register_variable!(value, cur_value)
-            result = expression.evaluated(local)
+            result = expression.evaluated(local).to_node
 
             case result
             when AST::Boolean

--- a/lib/keisan/functions/if.rb
+++ b/lib/keisan/functions/if.rb
@@ -13,12 +13,13 @@ module Keisan
       def evaluate(ast_function, context = nil)
         validate_arguments!(ast_function.children.count)
         context ||= Context.new
-
-        bool = ast_function.children[0].evaluate(context)
+        bool = ast_function.children[0].evaluate(context).to_node
 
         if bool.is_a?(AST::Boolean)
           node = bool.value ? ast_function.children[1] : ast_function.children[2]
           node.to_node.evaluate(context)
+        elsif bool.is_constant?
+          raise Keisan::Exceptions::InvalidFunctionError.new("if statement must work on booleans, other constants are not supported")
         else
           ast_function
         end
@@ -27,7 +28,7 @@ module Keisan
       def simplify(ast_function, context = nil)
         validate_arguments!(ast_function.children.count)
         context ||= Context.new
-        bool = ast_function.children[0].simplify(context)
+        bool = ast_function.children[0].simplify(context).to_node
 
         if bool.is_a?(AST::Boolean)
           if bool.value
@@ -37,6 +38,8 @@ module Keisan
           else
             Keisan::AST::Null.new
           end
+        elsif bool.is_constant?
+          raise Keisan::Exceptions::InvalidFunctionError.new("if statement must work on booleans, other constants are not supported")
         else
           ast_function
         end

--- a/lib/keisan/version.rb
+++ b/lib/keisan/version.rb
@@ -1,3 +1,3 @@
 module Keisan
-  VERSION = "0.8.12"
+  VERSION = "0.8.13"
 end

--- a/spec/keisan/ast/cell_spec.rb
+++ b/spec/keisan/ast/cell_spec.rb
@@ -31,4 +31,12 @@ RSpec.describe Keisan::AST::Cell do
       expect(cell.to_node).to eq node
     end
   end
+
+  describe "#to_cell" do
+    it "wraps the node in a new cell" do
+      new_cell = cell.to_cell
+      expect(cell).not_to eq new_cell
+      expect(cell.node).to eq new_cell.node
+    end
+  end
 end

--- a/spec/keisan/ast/logical_spec.rb
+++ b/spec/keisan/ast/logical_spec.rb
@@ -37,5 +37,29 @@ RSpec.describe Keisan::AST::LogicalOperator do
       expect(calculator.simplify("false || (x = 1)").value).to be 1
       expect(calculator.simplify("x").value).to eq 1
     end
+
+    context "with embedded list/hash values" do
+      it "logical and still short-circuits" do
+        calculator.evaluate("xs = [true, false]")
+
+        expect(calculator.evaluate("xs[0] && (a = 1)")).to eq 1
+        expect(calculator.evaluate("a")).to eq 1
+        expect(calculator.evaluate("xs[1] && (b = 2)")).to eq false
+        expect{calculator.evaluate("b")}.to raise_error(Keisan::Exceptions::UndefinedVariableError)
+      end
+
+      it "logical or still short-circuits" do
+        calculator.evaluate("hs = {'t': true, 'f': false}")
+        expect(calculator.evaluate("hs['t'] || (c = 3)")).to eq true
+        expect{calculator.evaluate("c")}.to raise_error(Keisan::Exceptions::UndefinedVariableError)
+        expect(calculator.evaluate("hs['f'] || (d = 4)")).to eq 4
+        expect(calculator.evaluate("d")).to eq 4
+      end
+
+      it "can compare embedded numbers" do
+        calculator.evaluate("as = [1, 2, 3]")
+        expect(calculator.evaluate("as[2] > as[0]")).to eq true
+      end
+    end
   end
 end

--- a/spec/keisan/default_functions_spec.rb
+++ b/spec/keisan/default_functions_spec.rb
@@ -97,36 +97,6 @@ RSpec.describe Keisan::Functions::DefaultRegistry do
         end
       end
 
-      describe "#filter" do
-        it "filters the list given the logical expression" do
-          expect{Keisan::Calculator.new.evaluate("filter(10, x, x > 0)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
-          expect{Keisan::Calculator.new.evaluate("filter([-1,0,1], 4, x > 0)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
-          expect{Keisan::Calculator.new.evaluate("filter([-1,0,1], x, x)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
-          expect(Keisan::Calculator.new.evaluate("filter([-1,0,1], x, x > 0)")).to eq [1]
-          expect(Keisan::Calculator.new.evaluate("select([1,2,3,4], x, x % 2 == 0)")).to eq [2,4]
-          expect(Keisan::Calculator.new.simplify("[1,3,5].filter(x, x == 3)").to_s).to eq "[3]"
-          expect(Keisan::Calculator.new.evaluate("l.filter(x, x['a'] == 2)", l: [{ 'a' => 2 }, { 'a' => 3 }]))
-            .to eq([{ 'a' => 2 }])
-          expect(Keisan::Calculator.new.evaluate("h['l'].filter(x, x['a'] == 2)", h: { 'l' => [{ 'a' => 2 }, { 'a' => 3 }] }))
-            .to eq([{ 'a' => 2 }])
-          expect(Keisan::Calculator.new.evaluate("l[0].filter(x, x['a'] == 2)", l: [[{ 'a' => 2 }, { 'a' => 3 }] ]))
-            .to eq([{ 'a' => 2 }])
-        end
-
-        it "filters the hash given the logical expression" do
-          expect{Keisan::Calculator.new.evaluate("filter(10, k, v, v > 0)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
-          expect{Keisan::Calculator.new.evaluate("filter({'a': 1, 'b': 2}, k, 2, k > 0)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
-          expect{Keisan::Calculator.new.evaluate("filter({'a': 1, 'b': 2}, k, v, k)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
-          expect(Keisan::Calculator.new.evaluate("filter({'a': 1, 'bb': 2}, k, v, k.size == 2)")).to eq({"bb" => 2})
-          expect(Keisan::Calculator.new.evaluate("h.filter(k, v, k == 'a')", h: { 'a' => 2, 'b' => 3 }))
-            .to eq({ 'a' => 2 })
-          expect(Keisan::Calculator.new.evaluate("h['hh'].filter(k, v, k == 'a')", h: { 'hh' => { 'a' => 2, 'b' => 3 } }))
-            .to eq({ 'a' => 2 })
-          expect(Keisan::Calculator.new.evaluate("l[0].filter(k, v, k == 'a')", l: [{ 'a' => 2, 'b' => 3 }]))
-            .to eq({ 'a' => 2 })
-        end
-      end
-
       describe "#reduce" do
         it "reduces the list given an expression" do
           expect{Keisan::Calculator.new.evaluate("reduce(1, 2, 3)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)

--- a/spec/keisan/functions/filter_spec.rb
+++ b/spec/keisan/functions/filter_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+RSpec.describe Keisan::Functions::Filter do
+  it "should be in the default context" do
+    c = Keisan::Context.new
+    expect(c.function("filter")).to be_a(described_class)
+  end
+
+  it "filters the list given the logical expression" do
+    expect{Keisan::Calculator.new.evaluate("filter(10, x, x > 0)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+    expect{Keisan::Calculator.new.evaluate("filter([-1,0,1], 4, x > 0)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+    expect{Keisan::Calculator.new.evaluate("filter([-1,0,1], x, x)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+    expect(Keisan::Calculator.new.evaluate("filter([-1,0,1], x, x > 0)")).to eq [1]
+    expect(Keisan::Calculator.new.evaluate("select([1,2,3,4], x, x % 2 == 0)")).to eq [2,4]
+    expect(Keisan::Calculator.new.simplify("[1,3,5].filter(x, x == 3)").to_s).to eq "[3]"
+    expect(Keisan::Calculator.new.evaluate("l.filter(x, x['a'] == 2)", l: [{ 'a' => 2 }, { 'a' => 3 }]))
+      .to eq([{ 'a' => 2 }])
+    expect(Keisan::Calculator.new.evaluate("h['l'].filter(x, x['a'] == 2)", h: { 'l' => [{ 'a' => 2 }, { 'a' => 3 }] }))
+      .to eq([{ 'a' => 2 }])
+    expect(Keisan::Calculator.new.evaluate("l[0].filter(x, x['a'] == 2)", l: [[{ 'a' => 2 }, { 'a' => 3 }] ]))
+      .to eq([{ 'a' => 2 }])
+    expect(Keisan::Calculator.new.evaluate("l.filter(x, x[0])", l: [[true, 'a'], [false, 'b']]))
+      .to eq([[true, 'a']])
+  end
+
+  it "filters the hash given the logical expression" do
+    expect{Keisan::Calculator.new.evaluate("filter(10, k, v, v > 0)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+    expect{Keisan::Calculator.new.evaluate("filter({'a': 1, 'b': 2}, k, 2, k > 0)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+    expect{Keisan::Calculator.new.evaluate("filter({'a': 1, 'b': 2}, k, v, k)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+    expect(Keisan::Calculator.new.evaluate("filter({'a': 1, 'bb': 2}, k, v, k.size == 2)")).to eq({"bb" => 2})
+    expect(Keisan::Calculator.new.evaluate("h.filter(k, v, k == 'a')", h: { 'a' => 2, 'b' => 3 }))
+      .to eq({ 'a' => 2 })
+    expect(Keisan::Calculator.new.evaluate("h['hh'].filter(k, v, k == 'a')", h: { 'hh' => { 'a' => 2, 'b' => 3 } }))
+      .to eq({ 'a' => 2 })
+    expect(Keisan::Calculator.new.evaluate("l[0].filter(k, v, k == 'a')", l: [{ 'a' => 2, 'b' => 3 }]))
+      .to eq({ 'a' => 2 })
+    expect(Keisan::Calculator.new.evaluate("h.filter(k, v, v[0])", h: {'a' => [true, 'aa'], 'b' => [false, 'bb']}))
+      .to eq({'a' => [true, 'aa']})
+  end
+end

--- a/spec/keisan/functions/if_spec.rb
+++ b/spec/keisan/functions/if_spec.rb
@@ -6,6 +6,27 @@ RSpec.describe Keisan::Functions::If do
     expect(c.function("if")).to be_a(described_class)
   end
 
+  it "can use logical values from variables" do
+    calculator = Keisan::Calculator.new
+    calculator.evaluate("a = true")
+    calculator.evaluate("b = false")
+    expect(calculator.evaluate("if(a, 5, 10)")).to eq 5
+    expect(calculator.evaluate("if(b, 5, 10)")).to eq 10
+  end
+
+  it "can use logical values from lists" do
+    calculator = Keisan::Calculator.new
+    calculator.evaluate("l = [true, false]")
+    expect(calculator.evaluate("if(l[0], 5, 10)")).to eq 5
+    expect(calculator.evaluate("if(l[1], 5, 10)")).to eq 10
+  end
+
+  it "can use logical values from hashes" do
+    calculator = Keisan::Calculator.new
+    calculator.evaluate("h = {'a': true, 'b': false}")
+    expect(calculator.evaluate("if(h['a'], 5, 10)")).to eq 5
+  end
+
   describe "simplify" do
     it "short circuits if the conditional is a boolean" do
       ast = Keisan::AST.parse("if(N, x, y)")
@@ -44,5 +65,14 @@ RSpec.describe Keisan::Functions::If do
     expect(calculator.evaluate("y")).to eq 1
     calculator.evaluate("if(x < 0, z = 1, z = 2)")
     expect(calculator.evaluate("z")).to eq 2
+  end
+
+  it "must have boolean in condition expression" do
+    calculator = Keisan::Calculator.new
+    calculator.evaluate("x = 0")
+    expect{calculator.simplify("if(x, 1, 2)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+    expect{calculator.simplify("if('foo', 'bar', 'baz')")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+    expect{calculator.evaluate("if(x, 1, 2)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+    expect{calculator.evaluate("if('foo', 'bar', 'baz')")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
   end
 end

--- a/spec/keisan/functions/while_spec.rb
+++ b/spec/keisan/functions/while_spec.rb
@@ -27,9 +27,45 @@ RSpec.describe Keisan::Functions::While do
     expect(calculator.evaluate("[1,2,3].includes(4)")).to eq false
   end
 
-  it "must have boolean in condition expression" do
-    calculator = Keisan::Calculator.new
-    calculator.evaluate("x = 0")
-    expect{calculator.evaluate("while(!x, x = x + 1)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+  describe "simplify" do
+    it "evaluates while loop if given boolean" do
+      calculator = Keisan::Calculator.new
+      calculator.evaluate("x = 0")
+      res = calculator.simplify("while(x < 4, x = x + 1); x")
+      expect(res).to be_a(Keisan::AST::Number)
+      expect(res.value).to eq 4
+    end
+
+    it "raises an error if given a constant non-boolean" do
+      calculator = Keisan::Calculator.new
+      calculator.evaluate("x = 0")
+      expect{calculator.simplify("while(!x, x = x + 1); x")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+    end
+
+    it "leaves as original AST if cannot determine what the logical field is" do
+      calculator = Keisan::Calculator.new
+      res = calculator.simplify("while(!x, x = x + 1)")
+      expect(res).to be_a(Keisan::AST::Function)
+      expect(res.name).to eq "while"
+    end
+  end
+
+  describe "evaluate" do
+    it "evaluates while loop if given boolean" do
+      calculator = Keisan::Calculator.new
+      calculator.evaluate("x = 0")
+      expect(calculator.evaluate("while(x < 4, x = x + 1); x")).to eq 4
+    end
+
+    it "raises an error if given a constant non-boolean" do
+      calculator = Keisan::Calculator.new
+      calculator.evaluate("x = 0")
+      expect{calculator.evaluate("while(!x, x = x + 1); x")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+    end
+
+    it "raises an error if cannot determine what the logical field is" do
+      calculator = Keisan::Calculator.new
+      expect{calculator.evaluate("while(!x, x = x + 1)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+    end
   end
 end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -2,6 +2,6 @@ require "spec_helper"
 
 RSpec.describe Keisan do
   it "has the expected version number" do
-    expect(Keisan::VERSION).to eq "0.8.12"
+    expect(Keisan::VERSION).to eq "0.8.13"
   end
 end


### PR DESCRIPTION
Previously, innocuous statements like `"if(x[0], x[1], x[2])"` could cause problems because of the way list/hash values are unwrapped. This problem exists wherever boolean statements are used, e.g. if statements, while loops, and filters.

This PR fixes the issue by unwrapping `Keisan::AST::Cell` objects for the purpose of checking the boolean value wherever possible. It also now will raise errors if these logical functions receive non-boolean constants as arguments (e.g. `"if(x[0], ...)"` when `x[0]` evaluates to say a string `"foo"`).