### PR TITLE
Fix handling of unary logical nots

### DIFF
--- a/lib/keisan/ast/unary_logical_not.rb
+++ b/lib/keisan/ast/unary_logical_not.rb
@@ -8,6 +8,32 @@ module Keisan
       def self.symbol
         :"!"
       end
+
+      def evaluate(context = nil)
+        context ||= Context.new
+        node = child.evaluate(context).to_node
+        case node
+        when AST::Boolean
+          AST::Boolean.new(!node.value)
+        else
+          if node.is_constant?
+            raise Keisan::Exceptions::InvalidFunctionError.new("Cannot take unary logical not of non-boolean constant")
+          else
+            super
+          end
+        end
+      end
+
+      def simplify(context = nil)
+        context ||= Context.new
+        node = child.simplify(context).to_node
+        case node
+        when AST::Boolean
+          AST::Boolean.new(!node.value)
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/spec/keisan/ast/logical_spec.rb
+++ b/spec/keisan/ast/logical_spec.rb
@@ -24,6 +24,29 @@ RSpec.describe Keisan::AST::LogicalOperator do
       expect(calculator.evaluate("a[i] > 0")).to be true
       expect(calculator.evaluate("a[i] >= 0")).to be true
     end
+
+    context "unary logical not" do
+      it "works as expected" do
+        expect(calculator.evaluate("!true")).to eq false
+        calculator.evaluate("t = true")
+        calculator.evaluate("f = false")
+        calculator.evaluate("l = [false, true]")
+        calculator.evaluate("h = {'f': false, 't': true}")
+        expect(calculator.evaluate("!t")).to eq false
+        expect(calculator.evaluate("!f")).to eq true
+        expect(calculator.evaluate("!l[0]")).to eq true
+        expect(calculator.evaluate("!l[1]")).to eq false
+        expect(calculator.evaluate("!h['t']")).to eq false
+        expect(calculator.evaluate("!h['f']")).to eq true
+
+        expect(calculator.evaluate("if(!t, 1, 2)")).to eq 2
+        expect(calculator.evaluate("if(!f, 1, 2)")).to eq 1
+        expect(calculator.evaluate("if(!l[0], 1, 2)")).to eq 1
+        expect(calculator.evaluate("if(!l[1], 1, 2)")).to eq 2
+        expect(calculator.evaluate("if(!h['f'], 1, 2)")).to eq 1
+        expect(calculator.evaluate("if(!h['t'], 1, 2)")).to eq 2
+      end
+    end
   end
 
   describe "simplify" do

--- a/spec/keisan/functions/filter_spec.rb
+++ b/spec/keisan/functions/filter_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Keisan::Functions::Filter do
       .to eq([{ 'a' => 2 }])
     expect(Keisan::Calculator.new.evaluate("l.filter(x, x[0])", l: [[true, 'a'], [false, 'b']]))
       .to eq([[true, 'a']])
+    expect(Keisan::Calculator.new.evaluate("l.filter(x, !x[0])", l: [[true, 'a'], [false, 'b']]))
+      .to eq([[false, 'b']])
   end
 
   it "filters the hash given the logical expression" do
@@ -36,5 +38,7 @@ RSpec.describe Keisan::Functions::Filter do
       .to eq({ 'a' => 2 })
     expect(Keisan::Calculator.new.evaluate("h.filter(k, v, v[0])", h: {'a' => [true, 'aa'], 'b' => [false, 'bb']}))
       .to eq({'a' => [true, 'aa']})
+    expect(Keisan::Calculator.new.evaluate("h.filter(k, v, !v[0])", h: {'a' => [true, 'aa'], 'b' => [false, 'bb']}))
+      .to eq({'b' => [false, 'bb']})
   end
 end

--- a/spec/keisan/functions/if_spec.rb
+++ b/spec/keisan/functions/if_spec.rb
@@ -75,4 +75,14 @@ RSpec.describe Keisan::Functions::If do
     expect{calculator.evaluate("if(x, 1, 2)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
     expect{calculator.evaluate("if('foo', 'bar', 'baz')")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
   end
+
+  it "can deal with unary logical not" do
+    calculator = Keisan::Calculator.new
+    calculator.evaluate("a = true")
+    calculator.evaluate("b = [true, false, 'banana']")
+    expect(calculator.evaluate("if(!a, 1, 2)")).to eq 2
+    expect(calculator.evaluate("if(!b[0], 1, 2)")).to eq 2
+    expect(calculator.evaluate("if(!b[1], 1, 2)")).to eq 1
+    expect{calculator.evaluate("if(!b[2], 1, 2)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+  end
 end

--- a/spec/keisan/functions/while_spec.rb
+++ b/spec/keisan/functions/while_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe Keisan::Functions::While do
       expect(res).to be_a(Keisan::AST::Function)
       expect(res.name).to eq "while"
     end
+
+    it "works on unary logical not" do
+      calculator = Keisan::Calculator.new
+      calculator.evaluate("l = [false]")
+      res = calculator.simplify("x = 0; while(!l[0], x = 10; l[0] = true); x")
+      expect(res).to be_a(Keisan::AST::Number)
+      expect(res.value).to eq 10
+    end
   end
 
   describe "evaluate" do
@@ -66,6 +74,14 @@ RSpec.describe Keisan::Functions::While do
     it "raises an error if cannot determine what the logical field is" do
       calculator = Keisan::Calculator.new
       expect{calculator.evaluate("while(!x, x = x + 1)")}.to raise_error(Keisan::Exceptions::InvalidFunctionError)
+    end
+
+    it "works on unary logical not" do
+      calculator = Keisan::Calculator.new
+      calculator.evaluate("h = {'foo': false}")
+      res = calculator.simplify("x = 0; while(!h['foo'], x = 10; h['foo'] = true); x")
+      expect(res).to be_a(Keisan::AST::Number)
+      expect(res.value).to eq 10
     end
   end
 end


### PR DESCRIPTION
Boolean expressions for functions like if/while/filter would previously
have problems with unary logical not. This fixes the problem.

See also #118 for other similar work on logical and/or.