### PR TITLE
Do not store @parsing_operators on AST

### DIFF
--- a/lib/keisan/ast/operator.rb
+++ b/lib/keisan/ast/operator.rb
@@ -45,8 +45,6 @@ module Keisan
 
         children = Array(children)
         super(children)
-
-        @parsing_operators = parsing_operators
       end
 
       def evaluate_assignments(context = nil)

--- a/lib/keisan/ast/plus.rb
+++ b/lib/keisan/ast/plus.rb
@@ -3,7 +3,7 @@ module Keisan
     class Plus < ArithmeticOperator
       def initialize(children = [], parsing_operators = [])
         super
-        convert_minus_to_plus!
+        convert_minus_to_plus!(parsing_operators)
       end
 
       def self.symbol
@@ -87,8 +87,8 @@ module Keisan
         date_time + others.inject(0, &:+)
       end
 
-      def convert_minus_to_plus!
-        @parsing_operators.each.with_index do |parsing_operator, index|
+      def convert_minus_to_plus!(parsing_operators)
+        parsing_operators.each.with_index do |parsing_operator, index|
           if parsing_operator.is_a?(Parsing::Minus)
             @children[index+1] = UnaryMinus.new(@children[index+1])
           end

--- a/lib/keisan/ast/times.rb
+++ b/lib/keisan/ast/times.rb
@@ -3,7 +3,7 @@ module Keisan
     class Times < ArithmeticOperator
       def initialize(children = [], parsing_operators = [])
         super
-        convert_divide_to_inverse!
+        convert_divide_to_inverse!(parsing_operators)
       end
 
       def self.symbol
@@ -63,8 +63,8 @@ module Keisan
 
       private
 
-      def convert_divide_to_inverse!
-        @parsing_operators.each.with_index do |parsing_operator, index|
+      def convert_divide_to_inverse!(parsing_operators)
+        parsing_operators.each.with_index do |parsing_operator, index|
           if parsing_operator.is_a?(Parsing::Divide)
             @children[index+1] = UnaryInverse.new(@children[index+1])
           end


### PR DESCRIPTION
Having `@parsing_operators` stored on some AST nodes is not needed. It takes up extra memory and clutters the objects.