### PR TITLE
Caching ASTs

### DIFF
--- a/lib/keisan.rb
+++ b/lib/keisan.rb
@@ -55,6 +55,7 @@ require "keisan/ast/indexing"
 
 require "keisan/ast/line_builder"
 require "keisan/ast/builder"
+require "keisan/ast/cache"
 require "keisan/ast"
 
 require "keisan/function"

--- a/lib/keisan/ast/cache.rb
+++ b/lib/keisan/ast/cache.rb
@@ -1,0 +1,31 @@
+module Keisan
+  module AST
+    class Cache
+      def initialize
+        @cache = {}
+      end
+
+      def fetch_or_build(string)
+        return @cache[string] if @cache.has_key?(string)
+
+        build_from_scratch(string).tap do |ast|
+          unless frozen?
+            # Freeze the AST to keep it from changing in the cache
+            ast.freeze
+            @cache[string] = ast
+          end
+        end
+      end
+
+      def has_key?(string)
+        @cache.has_key?(string)
+      end
+
+      private
+
+      def build_from_scratch(string)
+        Builder.new(string: string).ast
+      end
+    end
+  end
+end

--- a/lib/keisan/calculator.rb
+++ b/lib/keisan/calculator.rb
@@ -4,13 +4,23 @@ module Keisan
 
     # Note, allow_recursive would be more appropriately named:
     # allow_unbound_functions_in_function_definitions, but it is too late for that.
-    def initialize(context: nil, allow_recursive: false, allow_blocks: true, allow_multiline: true, allow_random: true)
+    def initialize(context: nil, allow_recursive: false, allow_blocks: true, allow_multiline: true, allow_random: true, cache: nil)
       @context = context || Context.new(
         allow_recursive: allow_recursive,
         allow_blocks: allow_blocks,
         allow_multiline: allow_multiline,
         allow_random: allow_random
       )
+      @cache = case cache
+               when nil, false
+                 nil
+               when true
+                 AST::Cache.new
+               when AST::Cache
+                 cache
+               else
+                 raise Exceptions::StandardError.new("cache must be either nil, false, true, or an instance of Keisan::AST::Cache")
+               end
     end
 
     def allow_recursive
@@ -34,15 +44,15 @@ module Keisan
     end
 
     def evaluate(expression, definitions = {})
-      Evaluator.new(self).evaluate(expression, definitions)
+      Evaluator.new(self, cache: @cache).evaluate(expression, definitions)
     end
 
     def simplify(expression, definitions = {})
-      Evaluator.new(self).simplify(expression, definitions)
+      Evaluator.new(self, cache: @cache).simplify(expression, definitions)
     end
 
     def ast(expression)
-      Evaluator.new(self).parse_ast(expression)
+      Evaluator.new(self, cache: @cache).parse_ast(expression)
     end
 
     def define_variable!(name, value)

--- a/spec/keisan/ast/cache_spec.rb
+++ b/spec/keisan/ast/cache_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+RSpec.describe Keisan::AST::Cache do
+  describe "caching" do
+    context "not frozen" do
+      it "adds to the cache when calling #fetch_or_build" do
+        cache = described_class.new
+
+        expect(cache.instance_variable_get(:@cache)).to eq({})
+        expect(cache.has_key?("x+1")).to eq false
+        expect(cache.fetch_or_build("x+1")).to be_a(Keisan::AST::Plus)
+        expect(cache.instance_variable_get(:@cache).has_key?("x+1")).to eq true
+        expect(cache.has_key?("x+1")).to eq true
+        expect(cache.instance_variable_get(:@cache)["x+1"]).to be_a(Keisan::AST::Plus)
+        expect(cache.instance_variable_get(:@cache)["x+1"].to_s).to eq "x+1"
+      end
+    end
+
+    context "frozen" do
+      it "does not add to the cache when calling #fetch_or_build" do
+        cache = described_class.new
+        cache.freeze
+
+        expect(cache.instance_variable_get(:@cache)).to eq({})
+        expect(cache.has_key?("x+1")).to eq false
+        expect(cache.fetch_or_build("x+1")).to be_a(Keisan::AST::Plus)
+        expect(cache.instance_variable_get(:@cache)).to eq({})
+        expect(cache.has_key?("x+1")).to eq false
+      end
+    end
+  end
+
+  describe "x = 15; 10*x**2 + exp(-x/5.0)" do
+    it "should be at least 5 times faster than no caching" do
+      uncached_calculator = Keisan::Calculator.new
+
+      uncached_before = Time.now
+      100.times do
+        uncached_calculator.evaluate("x = 15; 10*x**2 + exp(-x/5.0)")
+      end
+      uncached_after = Time.now
+
+      cache = described_class.new
+      cached_calculator = Keisan::Calculator.new(cache: cache)
+
+      cached_before = Time.now
+      100.times do
+        cached_calculator.evaluate("x = 15; 10*x**2 + exp(-x/5.0)")
+      end
+      cached_after = Time.now
+
+      uncached_time = uncached_after - uncached_before
+      cached_time = cached_after - cached_before
+      expect(5*cached_time).to be < uncached_time
+    end
+  end
+end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "README.md" do
       digest = Digest::SHA256.hexdigest(content)
 
       # cat README.md | sha256sum
-      expected_digest = "e4a52a0f15d13f3edbba2caadb59c7aba7627c3be2623173e4bbc2e531362076"
+      expected_digest = "160413c61798b027b2a0766089dbfff5d8d778ddae986f5c249f2ae6309ebaeb"
       if digest != expected_digest
         raise "Invalid README file detected with SHA256 digest of #{digest}. Use command `cat README.md | sha256sum` to get correct digest if your changes to the README are safe. Aborting README test."
       end


### PR DESCRIPTION
Creates new class `Keisan::AST::Cache` to support caching computation of ASTs from strings. See the changes to the README for more details on this feature.