### PR TITLE
Method to evaluate/simplify an AST

### DIFF
--- a/lib/keisan/calculator.rb
+++ b/lib/keisan/calculator.rb
@@ -55,6 +55,10 @@ module Keisan
       Evaluator.new(self, cache: @cache).simplify(expression, definitions)
     end
 
+    def simplify_ast(ast, definitions = {})
+      Evaluator.new(self, cache: @cache).simplify_ast(ast, definitions: definitions)
+    end
+
     def ast(expression)
       Evaluator.new(self, cache: @cache).parse_ast(expression)
     end

--- a/lib/keisan/calculator.rb
+++ b/lib/keisan/calculator.rb
@@ -47,6 +47,10 @@ module Keisan
       Evaluator.new(self, cache: @cache).evaluate(expression, definitions)
     end
 
+    def evaluate_ast(ast, definitions = {})
+      Evaluator.new(self, cache: @cache).evaluate_ast(ast, definitions: definitions)
+    end
+
     def simplify(expression, definitions = {})
       Evaluator.new(self, cache: @cache).simplify(expression, definitions)
     end

--- a/lib/keisan/evaluator.rb
+++ b/lib/keisan/evaluator.rb
@@ -29,7 +29,11 @@ module Keisan
 
     def simplify(expression, definitions = {})
       context = calculator.context.spawn_child(definitions: definitions, transient: true)
-      ast = parse_ast(expression)
+      simplify_ast(parse_ast(expression), context: context)
+    end
+
+    def simplify_ast(ast, definitions: {}, context: nil)
+      context ||= calculator.context.spawn_child(definitions: definitions, transient: true)
       ast.simplified(context)
     end
 

--- a/lib/keisan/evaluator.rb
+++ b/lib/keisan/evaluator.rb
@@ -9,7 +9,11 @@ module Keisan
 
     def evaluate(expression, definitions = {})
       context = calculator.context.spawn_child(definitions: definitions, transient: true)
-      ast = parse_ast(expression)
+      evaluate_ast(parse_ast(expression), context: context)
+    end
+
+    def evaluate_ast(ast, definitions: {}, context: nil)
+      context ||= calculator.context.spawn_child(definitions: definitions, transient: true)
       last_line = last_line(ast)
 
       evaluation = ast.evaluated(context)

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -213,6 +213,13 @@ RSpec.describe Keisan::Calculator do
     end
   end
 
+  describe "#evaluate_ast" do
+    it "processes the given AST" do
+      expression = "x = 10; x**2 + 1"
+      expect(calculator.evaluate_ast(calculator.ast(expression))).to eq 101
+    end
+  end
+
   describe "defining variables and functions" do
     it "saves them in the calculators context" do
       calculator.define_variable!("x", 5)

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -220,6 +220,14 @@ RSpec.describe Keisan::Calculator do
     end
   end
 
+  describe "#simplify_ast" do
+    it "processes the given AST" do
+      result = calculator.simplify_ast(calculator.ast("0*x+1"))
+      expect(result).to be_a(Keisan::AST::Number)
+      expect(result.value).to eq 1
+    end
+  end
+
   describe "defining variables and functions" do
     it "saves them in the calculators context" do
       calculator.define_variable!("x", 5)


### PR DESCRIPTION
Creates methods `evaluate_ast` and `simplify_ast`, which are equivalent to `evaluate` and `simplify`, but work on ASTs instead of expressions. This allows one to for instance first compute the AST of an expression, do some checks on it, and then evaluating it without having to re-parse the expression.