### PR TITLE
Empty curly-braces is treated as a blank hash

### DIFF
--- a/lib/keisan/parser.rb
+++ b/lib/keisan/parser.rb
@@ -211,7 +211,8 @@ module Keisan
       when :square
         @components << Parsing::List.new(arguments_from_group(token))
       when :curly
-        if token.sub_tokens.any? {|token| token.is_a?(Tokens::Colon)}
+        # A hash either has a colon, or is empty
+        if token.sub_tokens.any? {|token| token.is_a?(Tokens::Colon)} || token.sub_tokens.empty?
           @components << Parsing::Hash.new(Util.array_split(token.sub_tokens) {|token| token.is_a?(Tokens::Comma)})
         else
           @components << Parsing::CurlyGroup.new(token.sub_tokens)

--- a/lib/keisan/parsing/hash.rb
+++ b/lib/keisan/parsing/hash.rb
@@ -4,9 +4,14 @@ module Keisan
       attr_reader :key_value_pairs
 
       def initialize(key_value_pairs)
-        @key_value_pairs = Array(key_value_pairs).map {|key_value_pair|
-          validate_and_extract_key_value_pair(key_value_pair)
-        }
+        key_value_pairs = Array(key_value_pairs)
+        if key_value_pairs.size == 1 && key_value_pairs.first.empty?
+          @key_value_pairs = []
+        else
+          @key_value_pairs = key_value_pairs.map {|key_value_pair|
+            validate_and_extract_key_value_pair(key_value_pair)
+          }
+        end
       end
 
       private

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -154,6 +154,12 @@ RSpec.describe Keisan::Calculator do
       expect(calculator.evaluate("h").value).to eq({"a" => 1, 10 => 3, true => "hello"})
     end
 
+    it "can add elements to a blank hash" do
+      calculator.evaluate("h = {}")
+      calculator.evaluate("h['foo'] = 'bar'")
+      expect(calculator.evaluate("h").value).to eq({"foo" => "bar"})
+    end
+
     describe "#to_s" do
       it "outputs correct hash format" do
         hash_string = "{'a': 1, 'b': 2}"

--- a/spec/keisan/parser_spec.rb
+++ b/spec/keisan/parser_spec.rb
@@ -695,6 +695,16 @@ RSpec.describe Keisan::Parser do
     end
 
     context "hash definition" do
+      it "works on empty hashes" do
+        parser = described_class.new(string: "{ }")
+        expect(parser.components.map(&:class)).to eq([Keisan::Parsing::Hash])
+        expect(parser.components.first.key_value_pairs).to be_empty
+
+        parser = described_class.new(string: "{x}")
+        expect(parser.components.map(&:class)).to eq([Keisan::Parsing::CurlyGroup])
+        expect(parser.components.first.components.map(&:class)).to eq([Keisan::Parsing::Variable])
+      end
+
       it "parses the hash correctly" do
         parser = described_class.new(string: "{'foo': 1, 'bar': x**2 + 1}")
 


### PR DESCRIPTION
Previously a simple expression like `"h = {}"` would set `h` to `nil`. This is because the curly braces would be recognized as a *block* instead of a *hash*. This PR updates the code to treat curly braces that have no internal content as a blank hash.