### PR TITLE
Can chain Proc functions with `map` and other enumerable functions

### DIFF
--- a/lib/keisan/functions/enumerable_function.rb
+++ b/lib/keisan/functions/enumerable_function.rb
@@ -54,7 +54,7 @@ module Keisan
       private
 
       def operand_arguments_expression_for(ast_function, context)
-        operand = ast_function.children[0].simplify(context)
+        operand = ast_function.children[0].evaluate(context)
         arguments = ast_function.children[1...-1]
         expression = ast_function.children[-1]
 

--- a/spec/keisan/default_functions_spec.rb
+++ b/spec/keisan/default_functions_spec.rb
@@ -63,6 +63,14 @@ RSpec.describe Keisan::Functions::DefaultRegistry do
             .to eq([4,6])
         end
 
+        it "can chain on proc functions" do
+          context = Keisan::Context.new
+          context.register_function!("uniq", Proc.new {|a| a.uniq})
+          calculator = Keisan::Calculator.new(context: context)
+
+          expect(calculator.evaluate("[1, 2, 3, 1].uniq.map(x, x**2)")).to eq([1, 4, 9])
+        end
+
         it "maps the hash to the given expression" do
           calculator = Keisan::Calculator.new
           expect(calculator.evaluate("{'a': 1, 'b': 2}.map(k, v, {let k = k+k; [k, 2v]}).to_h").value).to eq({


### PR DESCRIPTION
Currently trying to chain a function defined using a Proc with a function like `map` causes an error. This PR fixes this by calling `evaluate` on the lhs instead of `simplify` (which doesn't know how to simplify a Proc function).