### PR TITLE
Allow hash to be defined across multiple lines

### DIFF
--- a/lib/keisan/parsing/hash.rb
+++ b/lib/keisan/parsing/hash.rb
@@ -17,7 +17,12 @@ module Keisan
       private
 
       def validate_and_extract_key_value_pair(key_value_pair)
-        key, value = Util.array_split(key_value_pair) {|token| token.is_a?(Tokens::Colon)}
+        filtered_key_value_pair = key_value_pair.select {|token|
+          !token.is_a?(Tokens::LineSeparator)
+        }
+        key, value = Util.array_split(filtered_key_value_pair) {|token|
+          token.is_a?(Tokens::Colon)
+        }
         raise Exceptions::ParseError.new("Invalid hash") unless key.size == 1 && value.size >= 1
 
         key = key.first

--- a/spec/keisan/ast/hash_spec.rb
+++ b/spec/keisan/ast/hash_spec.rb
@@ -41,4 +41,10 @@ RSpec.describe Keisan::AST::Hash do
       expect(calculator.evaluate("[['a', 3], ['b', 7]].to_h").value).to eq({"a" => 3, "b" => 7})
     end
   end
+
+  it "can be defined across multiple lines" do
+    calculator = Keisan::Calculator.new
+    calculator.evaluate("h = {\n'a':\n'foo',\n'b': 'bar'}")
+    expect(calculator.evaluate("h")).to eq({"a" => "foo", "b" => "bar"})
+  end
 end

--- a/spec/keisan/ast/list_spec.rb
+++ b/spec/keisan/ast/list_spec.rb
@@ -41,4 +41,10 @@ RSpec.describe Keisan::AST::List do
       expect(result.to_s).to eq "[1,2,3,4]"
     end
   end
+
+  it "can be defined across multiple lines" do
+    calculator = Keisan::Calculator.new
+    calculator.evaluate("l = [\n'a',\n'foo'\n]")
+    expect(calculator.evaluate("l")).to eq(["a", "foo"])
+  end
 end


### PR DESCRIPTION
Previously, lists could be defined across multiple lines, but hashes could not. This PR makes this more consistent by also stripping out newlines from inside the curly-braces defining a hash.