### PR TITLE
Indexing can deep_dup and freeze indexes too

### DIFF
--- a/lib/keisan/ast/indexing.rb
+++ b/lib/keisan/ast/indexing.rb
@@ -8,6 +8,19 @@ module Keisan
         @indexes = indexes
       end
 
+      def deep_dup
+        dupped = super
+        dupped.instance_variable_set(
+          :@indexes, indexes.map(&:deep_dup)
+        )
+        dupped
+      end
+
+      def freeze
+        indexes.each(&:freeze)
+        super
+      end
+
       def value(context = nil)
         return child.value(context).send(:[], *indexes.map {|index| index.value(context)})
       end

--- a/spec/keisan/ast/indexing_spec.rb
+++ b/spec/keisan/ast/indexing_spec.rb
@@ -16,4 +16,35 @@ RSpec.describe Keisan::AST::Indexing do
       expect(ast.evaluate.value).to eq 3
     end
   end
+
+  describe "#deep_dup" do
+    it "duplicates the argument and index" do
+      ast1 = Keisan::AST.parse("x[i+1]")
+      ast2 = ast1.deep_dup
+
+      expect(ast1.children.size).to eq 1
+      expect(ast2.children.size).to eq 1
+      expect(ast1.children.first).not_to equal(ast2.children.first)
+
+      expect(ast1.indexes.size).to eq 1
+      expect(ast2.indexes.size).to eq 1
+      expect(ast1.indexes.first).not_to equal(ast2.indexes.first)
+    end
+  end
+
+  describe "#freeze" do
+    it "freezes indexes and children" do
+      ast = Keisan::AST.parse("x[i+1]")
+
+      expect(ast).not_to be_frozen
+      expect(ast.children.any?(&:frozen?)).to be false
+      expect(ast.indexes.any?(&:frozen?)).to be false
+
+      ast.freeze
+
+      expect(ast).to be_frozen
+      expect(ast.children.all?(&:frozen?)).to be true
+      expect(ast.indexes.all?(&:frozen?)).to be true
+    end
+  end
 end


### PR DESCRIPTION
Previously the methods `#deep_dup` and `#freeze` were not defined for `Indexing` AST objects, which means they only duplicate and freeze the arguments and not the indexes in an expression like `arg[index]`. This PR fixes this problem.