### PR TITLE
Ensure ExpressionFunctions are frozen

### DIFF
--- a/lib/keisan/functions/expression_function.rb
+++ b/lib/keisan/functions/expression_function.rb
@@ -14,6 +14,12 @@ module Keisan
         @transient_definitions = transient_definitions
       end
 
+      def freeze
+        @arguments.freeze
+        @expression.freeze
+        super
+      end
+
       def call(context, *args)
         validate_arguments!(args.count)
 
@@ -96,7 +102,7 @@ module Keisan
       private
 
       def argument_variables
-        @argument_variables ||= arguments.map {|argument| AST::Variable.new(argument)}
+        arguments.map {|argument| AST::Variable.new(argument)}
       end
 
       def calculate_partial_derivatives(context)

--- a/lib/keisan/functions/registry.rb
+++ b/lib/keisan/functions/registry.rb
@@ -44,6 +44,9 @@ module Keisan
         when Proc
           self[name] = ProcFunction.new(name, function)
         when Function
+          # The expression AST which represents the function should be constant,
+          # so we freeze it so it will always have the same behavior.
+          function.freeze if function.is_a?(ExpressionFunction)
           self[name] = function
         else
           raise Exceptions::InvalidFunctionError.new

--- a/spec/keisan/functions/registry_spec.rb
+++ b/spec/keisan/functions/registry_spec.rb
@@ -55,4 +55,17 @@ RSpec.describe Keisan::Functions::Registry do
       expect(parent_registry["parent_function"].call(nil).value).to eq 5
     end
   end
+
+  it "should freeze expression functions" do
+    function = Keisan::Functions::ExpressionFunction.new(
+      "foo",
+      ["x"],
+      Keisan::AST.parse("x + 1"),
+      {}
+    )
+    registry.register!("foo", function)
+
+    expect(registry["foo"]).to be_frozen
+    expect(registry["foo"].expression).to be_frozen
+  end
 end


### PR DESCRIPTION
Do not want expressions that are saved in a function to ever change, so we freeze them.