### PR TITLE
Add set methods for lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,14 @@ calculator.evaluate("range(5,10)")
 #=> [5,6,7,8,9]
 calculator.evaluate("range(0,10,2)")
 #=> [0,2,4,6,8]
+calculator.evaluate("[1, 2, 2, 3].uniq")
+#=> [1,2,3]
+calculator.evaluate("[1, 2, 3].difference([2, 3, 4])")
+#=> [1]
+calculator.evaluate("[1, 2, 3].intersection([2, 3, 4])")
+#=> [2, 3]
+calculator.evaluate("[1, 2, 3].union([2, 3, 4])")
+#=> [1, 2, 3, 4]
 ```
 
 ##### Hashes

--- a/lib/keisan/functions/default_registry.rb
+++ b/lib/keisan/functions/default_registry.rb
@@ -122,6 +122,9 @@ module Keisan
           registry.register!(method, Proc.new {|a| a.send(method)}, force: true)
         end
 
+        registry.register!(:difference, Proc.new {|a, b| a - b}, force: true)
+        registry.register!(:intersection, Proc.new {|a, b| a & b}, force: true)
+        registry.register!(:union, Proc.new {|a, b| a | b}, force: true)
         registry.register!("range", Functions::Range.new, force: true)
       end
 

--- a/lib/keisan/functions/default_registry.rb
+++ b/lib/keisan/functions/default_registry.rb
@@ -118,7 +118,7 @@ module Keisan
       end
 
       def self.register_array_methods!(registry)
-        %i(min max size flatten reverse).each do |method|
+        %i(min max size flatten reverse uniq).each do |method|
           registry.register!(method, Proc.new {|a| a.send(method)}, force: true)
         end
 

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -114,6 +114,10 @@ RSpec.describe Keisan::Calculator do
       expect(calculator.evaluate("[1, 2, 3].intersection([2, 3, 4])")).to eq([2, 3])
       expect(calculator.evaluate("[1, 2, 3].union([2, 3, 4])")).to eq([1, 2, 3, 4])
     end
+
+    it "can call uniq" do
+      expect(calculator.evaluate("[1, 1, 2, 2, 2, 'a', 'b', 'a'].uniq")).to eq([1, 2, 'a', 'b'])
+    end
   end
 
   context "hash operations" do

--- a/spec/keisan/calculator_spec.rb
+++ b/spec/keisan/calculator_spec.rb
@@ -105,6 +105,15 @@ RSpec.describe Keisan::Calculator do
       calculator.evaluate("h['c'][1] = a[2]['b']")
       expect(calculator.evaluate("h").value).to eq({"c" => [1,33,3], "d" => 4})
     end
+
+    it "can do set operations on lists like in Ruby" do
+      expect(calculator.evaluate("[1, 1, 2, 2, 3, 3, 3, 3].difference([2, 3, 4])")).to eq([1, 1])
+      expect(calculator.evaluate("[1, 1, 2, 2, 3, 3, 3, 3].intersection([2, 3, 4])")).to eq([2, 3])
+      expect(calculator.evaluate("[1, 1, 2, 2, 3, 3, 3, 3].union([2, 3, 4])")).to eq([1, 2, 3, 4])
+      expect(calculator.evaluate("[1, 2, 3].difference([2, 3, 4])")).to eq([1])
+      expect(calculator.evaluate("[1, 2, 3].intersection([2, 3, 4])")).to eq([2, 3])
+      expect(calculator.evaluate("[1, 2, 3].union([2, 3, 4])")).to eq([1, 2, 3, 4])
+    end
   end
 
   context "hash operations" do

--- a/spec/keisan/default_functions_spec.rb
+++ b/spec/keisan/default_functions_spec.rb
@@ -65,10 +65,10 @@ RSpec.describe Keisan::Functions::DefaultRegistry do
 
         it "can chain on proc functions" do
           context = Keisan::Context.new
-          context.register_function!("uniq", Proc.new {|a| a.uniq})
+          context.register_function!("unique", Proc.new {|a| a.uniq})
           calculator = Keisan::Calculator.new(context: context)
 
-          expect(calculator.evaluate("[1, 2, 3, 1].uniq.map(x, x**2)")).to eq([1, 4, 9])
+          expect(calculator.evaluate("[1, 2, 3, 1].unique.map(x, x**2)")).to eq([1, 4, 9])
         end
 
         it "maps the hash to the given expression" do

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "README.md" do
       digest = Digest::SHA256.hexdigest(content)
 
       # cat README.md | sha256sum
-      expected_digest = "160413c61798b027b2a0766089dbfff5d8d778ddae986f5c249f2ae6309ebaeb"
+      expected_digest = "fe7bd43f92ca0bc4f4a0eafd25097c15d81addff17275ab785bd56549c8ff0c3"
       if digest != expected_digest
         raise "Invalid README file detected with SHA256 digest of #{digest}. Use command `cat README.md | sha256sum` to get correct digest if your changes to the README are safe. Aborting README test."
       end


### PR DESCRIPTION
Resolves #129.

Adds four new methods: `difference`, `intersection`, `union`, and `uniq`. These are defined to behave just like in Ruby. So one caveat is that `difference` will return the same element multiple times if it occurs multiple times in the LHS (see test included in this PR). Otherwise, these first 3 behave just like their set theoretical counterparts, and if you ensure that each list has no duplicates using `uniq` then the functions should behave exactly like the set ones.