### PR TITLE
Save variables assigned in multiline expression to context

### DIFF
--- a/lib/keisan/ast/assignment.rb
+++ b/lib/keisan/ast/assignment.rb
@@ -50,8 +50,7 @@ module Keisan
 
       def unbound_variables(context = nil)
         variables = super(context)
-        if is_variable_definition?
-          context.register_variable!(children.first.name, children.last) if context
+        if is_variable_definition? && children.first != children.last
           variables.delete(children.first.name)
         else
           variables

--- a/lib/keisan/ast/assignment.rb
+++ b/lib/keisan/ast/assignment.rb
@@ -51,6 +51,7 @@ module Keisan
       def unbound_variables(context = nil)
         variables = super(context)
         if is_variable_definition?
+          context.register_variable!(children.first.name, children.last) if context
           variables.delete(children.first.name)
         else
           variables

--- a/lib/keisan/ast/multi_line.rb
+++ b/lib/keisan/ast/multi_line.rb
@@ -23,6 +23,21 @@ module Keisan
       def to_s
         children.map(&:to_s).join(";")
       end
+
+      def unbound_variables(context = nil)
+        context ||= Context.new
+        unbound_variables = Set.new
+        defined_variables = Set.new
+        children.each do |child|
+          if child.is_a?(Assignment) && child.is_variable_definition?
+            variable = child.children.first
+            value = child.children.last
+            defined_variables.add(variable.name) unless variable == value
+          end
+          unbound_variables |= child.unbound_variables(context) - defined_variables
+        end
+        unbound_variables
+      end
     end
   end
 end

--- a/spec/keisan/ast/assignment_spec.rb
+++ b/spec/keisan/ast/assignment_spec.rb
@@ -397,11 +397,24 @@ RSpec.describe Keisan::AST::Assignment do
   end
 
   describe "unbound_variables" do
-    context "multi-line" do
-      it "binds assigned variables" do
-        context = Keisan::Context.new
-        ast = Keisan::AST.parse("x = 5; y = 6; x + y")
-        expect(ast.unbound_variables(context)).to eq Set.new
+    it "reports unbound variables" do
+      node = Keisan::AST.parse("x = 1")
+      expect(node.unbound_variables).to eq Set.new
+
+      node = Keisan::AST.parse("x = y")
+      expect(node.unbound_variables).to eq Set.new(["y"])
+
+      node = Keisan::AST.parse("x = y + z")
+      expect(node.unbound_variables).to eq Set.new(["y", "z"])
+
+      node = Keisan::AST.parse("x = y = z")
+      expect(node.unbound_variables).to eq Set.new(["z"])
+    end
+
+    context "when variable is assigned to itself" do
+      it "returns the variable" do
+        node = Keisan::AST.parse("x = x")
+        expect(node.unbound_variables).to eq Set.new(["x"])
       end
     end
   end

--- a/spec/keisan/ast/assignment_spec.rb
+++ b/spec/keisan/ast/assignment_spec.rb
@@ -395,4 +395,14 @@ RSpec.describe Keisan::AST::Assignment do
       end
     end
   end
+
+  describe "unbound_variables" do
+    context "multi-line" do
+      it "binds assigned variables" do
+        context = Keisan::Context.new
+        ast = Keisan::AST.parse("x = 5; y = 6; x + y")
+        expect(ast.unbound_variables(context)).to eq Set.new
+      end
+    end
+  end
 end

--- a/spec/keisan/ast/mult_line_spec.rb
+++ b/spec/keisan/ast/mult_line_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+RSpec.describe Keisan::AST::MultiLine do
+  describe "unbound_variables" do
+    it "accounts for variables assigned internally" do
+      node = Keisan::AST.parse("x = x; x")
+      expect(node.unbound_variables).to eq Set.new(["x"])
+
+      node = Keisan::AST.parse("x = y; x")
+      expect(node.unbound_variables).to eq Set.new(["y"])
+
+      node = Keisan::AST.parse("x = 1; y = 1; x + y")
+      expect(node.unbound_variables).to eq Set.new
+
+      node = Keisan::AST.parse("x = 1; y = x; x + y")
+      expect(node.unbound_variables).to eq Set.new
+
+      node = Keisan::AST.parse("x = 1; y = x + z; y")
+      expect(node.unbound_variables).to eq Set.new(["z"])
+    end
+  end
+end


### PR DESCRIPTION
Yowhattup, so I ran into an issue where `unbound_variables` reported that a variable assigned inside a multiline expression was unbound and here's a lil fix.