### PR TITLE
Correct unbound variable handly in multi-line

### DIFF
--- a/lib/keisan/ast/multi_line.rb
+++ b/lib/keisan/ast/multi_line.rb
@@ -20,8 +20,48 @@ module Keisan
         evaluate(context)
       end
 
+      def unbound_variables(context = nil)
+        context ||= Context.new
+        defined_variables = Set.new
+
+        children.inject(Set.new) do |unbound_vars, child|
+          if child.is_a?(Assignment) && child.is_variable_definition?
+            line_unbound_vars = unbound_variables_for_line_variable_assignment(context, child, unbound_vars, defined_variables)
+            if line_unbound_vars.empty?
+              defined_variables.add(child.variable_name)
+            end
+            unbound_vars | line_unbound_vars
+          else
+            unbound_vars | (child.unbound_variables(context) - defined_variables)
+          end
+        end
+      end
+
       def to_s
         children.map(&:to_s).join(";")
+      end
+
+      private
+
+      def unbound_variables_for_line_variable_assignment(context, line, unbound_vars, defined_variables)
+        child_unbound_variables = variable_assignment_unbound_variables(context, line, defined_variables)
+        if child_unbound_variables.empty?
+          defined_variables.add(line.variable_name)
+          unbound_vars
+        else
+          unbound_vars | child_unbound_variables
+        end
+      end
+
+      def variable_assignment_unbound_variables(context, assignment, defined_variables)
+        rhs_child_unbound_variables = assignment.rhs_unbound_variables(context) - defined_variables
+
+        # If there are no unbound variables, this is a properly bound assignment.
+        if rhs_child_unbound_variables.empty?
+          Set.new
+        else
+          Set.new([assignment.variable_name]) | rhs_child_unbound_variables
+        end
       end
     end
   end

--- a/spec/keisan/ast/multi_line_spec.rb
+++ b/spec/keisan/ast/multi_line_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+RSpec.describe Keisan::AST::MultiLine do
+  describe "unbound_variables" do
+    let(:context) { Keisan::Context.new }
+
+    context "with empty context" do
+      it "binds assigned variables" do
+        ast = Keisan::AST.parse("x = 1; y = 2; x + y")
+        expect(ast.unbound_variables(context)).to eq Set.new
+      end
+
+      it "recognizes when one variable is assigned to" do
+        ast = Keisan::AST.parse("x = 3; y = 4; x + y")
+        expect(ast.unbound_variables(context)).to eq Set.new
+      end
+
+      it "recognizes when one variable is assigned to and one is not" do
+        ast = Keisan::AST.parse("x = 5; y = x + z; y")
+        expect(ast.unbound_variables(context)).to eq Set.new(["y", "z"])
+      end
+
+      it "propagates unbound variable" do
+        ast = Keisan::AST.parse("x = 1; y = x")
+        expect(ast.unbound_variables(context)).to eq Set.new
+      end
+    end
+
+    context "with one variable defined" do
+      let(:context) {
+        Keisan::Context.new.tap do |context|
+          context.register_variable!("x", 1)
+        end
+      }
+
+      it "handles case when y is defined" do
+        ast = Keisan::AST.parse("y = 5; x + y")
+        expect(ast.unbound_variables(context)).to eq Set.new
+      end
+
+      it "handles case when y is dependent on x" do
+        ast = Keisan::AST.parse("y = x; x + y")
+        expect(ast.unbound_variables(context)).to eq Set.new
+      end
+
+      it "propagates unbound variable" do
+        ast = Keisan::AST.parse("y = x + z; x + y")
+        expect(ast.unbound_variables(context)).to eq Set.new(["y", "z"])
+      end
+
+      it "propagates unbound variable" do
+        ast = Keisan::AST.parse("x = 1; y = x")
+        expect(ast.unbound_variables(context)).to eq Set.new
+      end
+    end
+  end
+end

--- a/spec/keisan/differentiation_spec.rb
+++ b/spec/keisan/differentiation_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe "Differentiation" do
     context "single variable" do
       it "can be used to assign variables" do
         calculator.evaluate("my_func(x) = x*log(x)")
-        expect(calculator.evaluate("my_func(10)")).to eq(10 * Math::log(10))
-        expect(calculator.evaluate("replace(diff(my_func(x), x), x, 10)")).to eq(1 + Math::log(10))
+        expect(calculator.evaluate("my_func(10)")).to be_within(0.0001).of(10 * Math::log(10))
+        expect(calculator.evaluate("replace(diff(my_func(x), x), x, 10)")).to be_within(0.0001).of(1 + Math::log(10))
       end
     end
 


### PR DESCRIPTION
Following up on #132, this updates the logic for `unbound_variables` to better handle multi-line statements. In particular, assignment like "x = 3" will now report no unbound variables, and multi-line statements like "x = 1; y = x" will also realize there are no unbound variables.